### PR TITLE
Add baseline mode for detecting NEW slop only

### DIFF
--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "createdAt": "2026-01-11T14:15:17.2189996+00:00",
+  "updatedAt": "2026-01-11T14:15:17.2189997+00:00",
+  "description": "Initial baseline created by \u0027slopwatch init\u0027 on 2026-01-11 14:15:17 UTC",
+  "entries": []
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
-    <LibGit2SharpVersion>0.31.0</LibGit2SharpVersion>
     <RoslynVersion>4.13.0</RoslynVersion>
     <CommandLineParserVersion>2.9.1</CommandLineParserVersion>
     <FileSystemGlobbingVersion>9.0.0</FileSystemGlobbingVersion>
@@ -13,7 +12,6 @@
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
-    <PackageVersion Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
     <PackageVersion Include="CommandLineParser" Version="$(CommandLineParserVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(FileSystemGlobbingVersion)" />

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ When LLMs generate code, they sometimes take shortcuts that make tests pass or b
 - **Suppressing warnings** instead of addressing them (`#pragma warning disable`)
 - **Swallowing exceptions** with empty catch blocks
 - **Adding arbitrary delays** to mask timing issues (`Task.Delay(1000)`)
+- **Project-level warning suppression** (`<NoWarn>`, `<TreatWarningsAsErrors>false</TreatWarningsAsErrors>`)
 - And more...
 
-Slopwatch catches these patterns in your git diffs before they make it into your codebase.
+Slopwatch catches these patterns before they make it into your codebase.
 
 ## Installation
 
@@ -24,49 +25,91 @@ dotnet tool install --global Slopwatch.Cmd
 dotnet tool install Slopwatch.Cmd
 ```
 
+## Quick Start
+
+```bash
+# 1. Install slopwatch
+dotnet tool install --global Slopwatch.Cmd
+
+# 2. Initialize in your project (creates baseline from existing code)
+cd your-project
+slopwatch init
+
+# 3. Commit the baseline to your repository
+git add .slopwatch/baseline.json
+git commit -m "Add slopwatch baseline"
+
+# 4. From now on, only NEW slop is detected
+slopwatch analyze
+```
+
+The baseline approach ensures slopwatch catches **new** slop being introduced without flagging legacy code. Your CI/CD pipeline will fail if someone introduces new slop patterns.
+
 ## Usage
 
-### Analyze current directory
+### Initialize a Project
+
 ```bash
-slopwatch analyze -d .
+# Create baseline from existing code
+slopwatch init
+
+# Force overwrite existing baseline
+slopwatch init --force
 ```
 
-### Analyze specific files
+This creates `.slopwatch/baseline.json` containing all existing detections. Commit this file to your repository.
+
+### Analyze for New Issues
+
 ```bash
-slopwatch analyze -f src/MyProject/MyFile.cs
+# Analyze current directory (requires baseline by default)
+slopwatch analyze
+
+# Analyze specific directory
+slopwatch analyze -d src/
+
+# Skip baseline and report ALL issues (not recommended for CI)
+slopwatch analyze --no-baseline
 ```
 
-### Use glob patterns
+### Update Baseline
+
+When you intentionally add code that triggers slopwatch (with proper justification):
+
 ```bash
-slopwatch analyze -d . -p "**/*.cs"
+# Add new detections to existing baseline
+slopwatch analyze --update-baseline
 ```
 
-### Output formats
+### Output Formats
+
 ```bash
 # Human-readable console output (default)
-slopwatch analyze -d .
+slopwatch analyze
 
 # JSON for programmatic use
-slopwatch analyze -d . --output json
+slopwatch analyze --output json
 ```
 
-### Exit codes
+### Exit Codes
+
 ```bash
 # Fail if errors found (default)
-slopwatch analyze -d . --fail-on error
+slopwatch analyze --fail-on error
 
 # Fail on warnings too
-slopwatch analyze -d . --fail-on warning
+slopwatch analyze --fail-on warning
 ```
 
 ## Detection Rules
 
-| Rule | Description |
-|------|-------------|
-| SW001 | Disabled tests via Skip, Ignore, or #if false |
-| SW002 | Warning suppression via pragma or SuppressMessage |
-| SW003 | Empty catch blocks that swallow exceptions |
-| SW004 | Arbitrary delays in test code |
+| Rule | Severity | Description |
+|------|----------|-------------|
+| SW001 | Error | Disabled tests via Skip, Ignore, or #if false |
+| SW002 | Warning | Warning suppression via pragma or SuppressMessage |
+| SW003 | Error | Empty catch blocks that swallow exceptions |
+| SW004 | Warning | Arbitrary delays in test code (Task.Delay, Thread.Sleep) |
+| SW005 | Warning | Project file slop (NoWarn, TreatWarningsAsErrors=false) |
 
 ## Claude Code Integration
 
@@ -98,6 +141,8 @@ The hook will run when you stop a coding session, analyzing all C# files in the 
 - name: Run Slopwatch
   run: slopwatch analyze -d . --output json --fail-on error
 ```
+
+**Note:** The baseline file (`.slopwatch/baseline.json`) should be committed to your repository. Run `slopwatch init` locally first.
 
 ### Azure DevOps
 ```yaml

--- a/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using Slopwatch.Analysis;
+using Slopwatch.Baseline;
 using Slopwatch.Cmd.Output;
 using Slopwatch.Detection;
 using Slopwatch.Detection.Rules;
@@ -36,6 +37,18 @@ public sealed class AnalyzeCommand
     [Option('c', "config", HelpText = "Path to configuration file")]
     public string? ConfigFile { get; set; }
 
+    [Option("baseline", HelpText = "Path to baseline file (default: .slopwatch/baseline.json)")]
+    public string BaselineFile { get; set; } = ".slopwatch/baseline.json";
+
+    [Option("no-baseline", HelpText = "Skip baseline checking - report ALL detections (useful for initial setup)")]
+    public bool NoBaseline { get; set; }
+
+    [Option("create-baseline", HelpText = "Create a baseline file from current detections (skips normal output)")]
+    public string? CreateBaseline { get; set; }
+
+    [Option("update-baseline", HelpText = "Add new detections to an existing baseline file")]
+    public bool UpdateBaseline { get; set; }
+
     /// <summary>
     /// Executes the analyze command.
     /// </summary>
@@ -44,6 +57,25 @@ public sealed class AnalyzeCommand
     {
         try
         {
+            // Validate mutually exclusive options
+            if (!string.IsNullOrEmpty(CreateBaseline) && UpdateBaseline)
+            {
+                await Console.Error.WriteLineAsync("Cannot use --create-baseline and --update-baseline together");
+                return 2;
+            }
+
+            if (NoBaseline && UpdateBaseline)
+            {
+                await Console.Error.WriteLineAsync("Cannot use --no-baseline and --update-baseline together");
+                return 2;
+            }
+
+            if (NoBaseline && !string.IsNullOrEmpty(CreateBaseline))
+            {
+                await Console.Error.WriteLineAsync("Cannot use --no-baseline and --create-baseline together");
+                return 2;
+            }
+
             // Parse severity levels
             if (!TryParseSeverity(MinSeverity, out var minSeverity))
             {
@@ -70,14 +102,51 @@ public sealed class AnalyzeCommand
                 options.ExcludePatterns = excludeList;
             }
 
+            // Determine root directory
+            var rootDirectory = Directory ?? System.IO.Directory.GetCurrentDirectory();
+
+            // Load baseline (required by default unless --no-baseline or --create-baseline)
+            Baseline.BaselineFile? baseline = null;
+            var useBaseline = !NoBaseline && string.IsNullOrEmpty(CreateBaseline);
+
+            // Resolve baseline path relative to root directory
+            var resolvedBaselinePath = Path.IsPathRooted(BaselineFile)
+                ? BaselineFile
+                : Path.Combine(rootDirectory, BaselineFile);
+
+            if (useBaseline)
+            {
+                baseline = await Baseline.BaselineFile.LoadAsync(resolvedBaselinePath, cancellationToken);
+
+                if (baseline is null && !UpdateBaseline)
+                {
+                    await Console.Error.WriteLineAsync($"Baseline file not found: {resolvedBaselinePath}");
+                    await Console.Error.WriteLineAsync();
+                    await Console.Error.WriteLineAsync("Slopwatch requires a baseline to detect NEW issues.");
+                    await Console.Error.WriteLineAsync("Run 'slopwatch init' to create a baseline from existing code.");
+                    await Console.Error.WriteLineAsync();
+                    await Console.Error.WriteLineAsync("Or use --no-baseline to analyze ALL code (not recommended for CI/CD).");
+                    return 2;
+                }
+
+                baseline ??= new Baseline.BaselineFile();
+
+                if (!UpdateBaseline)
+                {
+                    var countsByRule = baseline.GetEntriesByRule();
+                    var totalBaselined = baseline.Entries.Count;
+                    if (totalBaselined > 0)
+                    {
+                        await Console.Error.WriteLineAsync($"Loaded baseline with {totalBaselined} entries ({string.Join(", ", countsByRule.Select(kv => $"{kv.Key}: {kv.Value}"))})");
+                    }
+                }
+            }
+
             // Create all detection rules
             var rules = CreateDetectionRules();
 
             // Create file analyzer
             var analyzer = new FileAnalyzer(rules, options);
-
-            // Create output formatter
-            var formatter = CreateOutputFormatter();
 
             // Determine what to analyze
             IAsyncEnumerable<DetectionResult> results;
@@ -102,17 +171,36 @@ public sealed class AnalyzeCommand
             else
             {
                 // Analyze directory
-                var directory = Directory ?? System.IO.Directory.GetCurrentDirectory();
-
-                if (!System.IO.Directory.Exists(directory))
+                if (!System.IO.Directory.Exists(rootDirectory))
                 {
-                    await Console.Error.WriteLineAsync($"Directory not found: {directory}");
+                    await Console.Error.WriteLineAsync($"Directory not found: {rootDirectory}");
                     return 2;
                 }
 
                 var patterns = Patterns?.ToArray() ?? new[] { "**/*.cs", "**/*.csproj" };
-                results = analyzer.AnalyzeDirectoryAsync(directory, patterns, cancellationToken);
+                results = analyzer.AnalyzeDirectoryAsync(rootDirectory, patterns, cancellationToken);
             }
+
+            // Handle --create-baseline mode
+            if (!string.IsNullOrEmpty(CreateBaseline))
+            {
+                return await CreateBaselineAsync(results, rootDirectory, CreateBaseline, cancellationToken);
+            }
+
+            // Handle --update-baseline mode
+            if (UpdateBaseline && baseline is not null)
+            {
+                return await UpdateBaselineAsync(results, rootDirectory, baseline, resolvedBaselinePath, cancellationToken);
+            }
+
+            // Filter against baseline if specified
+            if (baseline is not null)
+            {
+                results = baseline.FilterNewDetectionsAsync(results, rootDirectory);
+            }
+
+            // Create output formatter
+            var formatter = CreateOutputFormatter();
 
             // Track results for exit code determination
             var issueTracker = new IssueTracker(failOnSeverity);
@@ -138,6 +226,75 @@ public sealed class AnalyzeCommand
             }
             return 2;
         }
+    }
+
+    private static async Task<int> CreateBaselineAsync(
+        IAsyncEnumerable<DetectionResult> results,
+        string rootDirectory,
+        string outputPath,
+        CancellationToken cancellationToken)
+    {
+        var allResults = new List<DetectionResult>();
+        await foreach (var result in results.WithCancellation(cancellationToken))
+        {
+            allResults.Add(result);
+        }
+
+        var baseline = Baseline.BaselineFile.Create(
+            allResults,
+            rootDirectory,
+            $"Baseline created on {DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+
+        await baseline.SaveAsync(outputPath, cancellationToken);
+
+        var countsByRule = baseline.GetEntriesByRule();
+        await Console.Out.WriteLineAsync($"Created baseline at: {outputPath}");
+        await Console.Out.WriteLineAsync($"Total entries: {baseline.Entries.Count}");
+
+        foreach (var (ruleId, count) in countsByRule.OrderBy(kv => kv.Key))
+        {
+            await Console.Out.WriteLineAsync($"  {ruleId}: {count}");
+        }
+
+        return 0;
+    }
+
+    private static async Task<int> UpdateBaselineAsync(
+        IAsyncEnumerable<DetectionResult> results,
+        string rootDirectory,
+        Baseline.BaselineFile baseline,
+        string baselinePath,
+        CancellationToken cancellationToken)
+    {
+        var addedCount = 0;
+        var skippedCount = 0;
+
+        await foreach (var result in results.WithCancellation(cancellationToken))
+        {
+            if (baseline.AddEntry(result, rootDirectory))
+            {
+                addedCount++;
+            }
+            else
+            {
+                skippedCount++;
+            }
+        }
+
+        if (addedCount > 0)
+        {
+            await baseline.SaveAsync(baselinePath, cancellationToken);
+            await Console.Out.WriteLineAsync($"Updated baseline at: {baselinePath}");
+            await Console.Out.WriteLineAsync($"  Added: {addedCount} new entries");
+            await Console.Out.WriteLineAsync($"  Skipped: {skippedCount} already baselined");
+            await Console.Out.WriteLineAsync($"  Total: {baseline.Entries.Count} entries");
+        }
+        else
+        {
+            await Console.Out.WriteLineAsync("No new entries to add to baseline");
+        }
+
+        return 0;
     }
 
     private static IEnumerable<IDetectionRule> CreateDetectionRules()

--- a/src/Slopwatch.Cmd/Commands/InitCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/InitCommand.cs
@@ -1,0 +1,200 @@
+using CommandLine;
+using Slopwatch.Analysis;
+using Slopwatch.Baseline;
+using Slopwatch.Detection;
+using Slopwatch.Detection.Rules;
+
+namespace Slopwatch.Cmd.Commands;
+
+/// <summary>
+/// Command for initializing slopwatch in a project.
+/// Creates .slopwatch directory and baseline file.
+/// </summary>
+[Verb("init", HelpText = "Initialize slopwatch in a project - creates baseline from existing code")]
+public sealed class InitCommand
+{
+    [Option('d', "directory", HelpText = "Directory to initialize (default: current directory)")]
+    public string? Directory { get; set; }
+
+    [Option('p', "patterns", HelpText = "Glob patterns to match (default: **/*.cs, **/*.csproj)", Separator = ',')]
+    public IEnumerable<string>? Patterns { get; set; }
+
+    [Option("exclude", HelpText = "Patterns to exclude", Separator = ',')]
+    public IEnumerable<string>? Exclude { get; set; }
+
+    [Option('f', "force", HelpText = "Overwrite existing baseline file if it exists")]
+    public bool Force { get; set; }
+
+    [Option("min-severity", HelpText = "Minimum severity to baseline: info, warning, error (default: info)")]
+    public string MinSeverity { get; set; } = "info";
+
+    /// <summary>
+    /// Executes the init command.
+    /// </summary>
+    /// <returns>Exit code: 0 = success, 1 = already initialized, 2 = error</returns>
+    public async Task<int> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var rootDirectory = Directory ?? System.IO.Directory.GetCurrentDirectory();
+
+            if (!System.IO.Directory.Exists(rootDirectory))
+            {
+                await Console.Error.WriteLineAsync($"Directory not found: {rootDirectory}");
+                return 2;
+            }
+
+            var slopwatchDir = Path.Combine(rootDirectory, ".slopwatch");
+            var baselinePath = Path.Combine(slopwatchDir, "baseline.json");
+            var configExamplePath = Path.Combine(slopwatchDir, "config.json.example");
+
+            // Check if already initialized
+            if (File.Exists(baselinePath) && !Force)
+            {
+                await Console.Error.WriteLineAsync($"Slopwatch already initialized at: {baselinePath}");
+                await Console.Error.WriteLineAsync("Use --force to overwrite existing baseline");
+                return 1;
+            }
+
+            // Parse severity
+            if (!TryParseSeverity(MinSeverity, out var minSeverity))
+            {
+                await Console.Error.WriteLineAsync($"Invalid min-severity: {MinSeverity}. Valid values: info, warning, error");
+                return 2;
+            }
+
+            await Console.Out.WriteLineAsync($"Initializing slopwatch in: {rootDirectory}");
+            await Console.Out.WriteLineAsync();
+
+            // Create .slopwatch directory
+            if (!System.IO.Directory.Exists(slopwatchDir))
+            {
+                System.IO.Directory.CreateDirectory(slopwatchDir);
+                await Console.Out.WriteLineAsync($"Created: {slopwatchDir}");
+            }
+
+            // Create analysis options
+            var options = new AnalysisOptions
+            {
+                MinimumSeverity = minSeverity
+            };
+
+            if (Exclude is not null && Exclude.Any())
+            {
+                var excludeList = options.ExcludePatterns.ToList();
+                excludeList.AddRange(Exclude);
+                options.ExcludePatterns = excludeList;
+            }
+
+            // Create all detection rules
+            var rules = CreateDetectionRules();
+            var analyzer = new FileAnalyzer(rules, options);
+
+            // Analyze directory
+            var patterns = Patterns?.ToArray() ?? new[] { "**/*.cs", "**/*.csproj" };
+
+            await Console.Out.WriteLineAsync("Scanning for existing issues...");
+
+            var allResults = new List<DetectionResult>();
+            await foreach (var result in analyzer.AnalyzeDirectoryAsync(rootDirectory, patterns, cancellationToken))
+            {
+                allResults.Add(result);
+            }
+
+            // Create baseline
+            var baseline = BaselineFile.Create(
+                allResults,
+                rootDirectory,
+                $"Initial baseline created by 'slopwatch init' on {DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+
+            await baseline.SaveAsync(baselinePath, cancellationToken);
+
+            // Create example config if it doesn't exist
+            if (!File.Exists(configExamplePath))
+            {
+                await CreateExampleConfigAsync(configExamplePath);
+            }
+
+            // Summary
+            await Console.Out.WriteLineAsync();
+            await Console.Out.WriteLineAsync("Slopwatch initialized successfully!");
+            await Console.Out.WriteLineAsync();
+            await Console.Out.WriteLineAsync($"  Baseline: {baselinePath}");
+            await Console.Out.WriteLineAsync($"  Entries:  {baseline.Entries.Count}");
+
+            if (baseline.Entries.Count > 0)
+            {
+                await Console.Out.WriteLineAsync();
+                await Console.Out.WriteLineAsync("  Baselined issues by rule:");
+                foreach (var (ruleId, count) in baseline.GetEntriesByRule().OrderBy(kv => kv.Key))
+                {
+                    await Console.Out.WriteLineAsync($"    {ruleId}: {count}");
+                }
+            }
+
+            await Console.Out.WriteLineAsync();
+            await Console.Out.WriteLineAsync("Next steps:");
+            await Console.Out.WriteLineAsync("  1. Commit .slopwatch/baseline.json to your repository");
+            await Console.Out.WriteLineAsync("  2. Run 'slopwatch analyze' to check for NEW issues");
+            await Console.Out.WriteLineAsync("  3. Add slopwatch to your CI/CD pipeline or Claude Code hooks");
+
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            await Console.Error.WriteLineAsync("Initialization cancelled");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync($"Error during initialization: {ex.Message}");
+            return 2;
+        }
+    }
+
+    private static IEnumerable<IDetectionRule> CreateDetectionRules()
+    {
+        yield return new DisabledTestRule();
+        yield return new WarningSuppressRule();
+        yield return new EmptyCatchBlockRule();
+        yield return new TimeoutJigglingRule();
+        yield return new ProjectFileRule();
+    }
+
+    private static bool TryParseSeverity(string severityText, out DetectionSeverity severity)
+    {
+        switch (severityText.ToLowerInvariant())
+        {
+            case "info":
+                severity = DetectionSeverity.Info;
+                return true;
+            case "warning":
+                severity = DetectionSeverity.Warning;
+                return true;
+            case "error":
+                severity = DetectionSeverity.Error;
+                return true;
+            default:
+                severity = default;
+                return false;
+        }
+    }
+
+    private static async Task CreateExampleConfigAsync(string path)
+    {
+        var exampleConfig = """
+            {
+              "suppressions": [
+                {
+                  "ruleId": "SW002",
+                  "pattern": "**/Generated/**",
+                  "justification": "Generated code from protobuf/gRPC compiler - cannot be modified"
+                }
+              ],
+              "globalSuppressions": []
+            }
+            """;
+
+        await File.WriteAllTextAsync(path, exampleConfig);
+    }
+}

--- a/src/Slopwatch.Cmd/Program.cs
+++ b/src/Slopwatch.Cmd/Program.cs
@@ -24,9 +24,10 @@ public static class Program
 
         try
         {
-            return await Parser.Default.ParseArguments<AnalyzeCommand, ListRulesCommand>(args)
+            return await Parser.Default.ParseArguments<AnalyzeCommand, InitCommand, ListRulesCommand>(args)
                 .MapResult(
                     (AnalyzeCommand cmd) => cmd.ExecuteAsync(cts.Token),
+                    (InitCommand cmd) => cmd.ExecuteAsync(cts.Token),
                     (ListRulesCommand cmd) => cmd.ExecuteAsync(cts.Token),
                     errors => Task.FromResult(2));
         }

--- a/src/Slopwatch/Baseline/BaselineEntry.cs
+++ b/src/Slopwatch/Baseline/BaselineEntry.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------
+// <copyright file="BaselineEntry.cs" company="Petabridge, LLC">
+//     Copyright (C) 2025 - 2025 Petabridge, LLC
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Slopwatch.Baseline;
+
+/// <summary>
+/// Represents a single detection that has been baselined (acknowledged as pre-existing).
+/// </summary>
+public sealed class BaselineEntry
+{
+    /// <summary>
+    /// Unique hash identifying this detection.
+    /// Computed from: RuleId + RelativeFilePath + CodeSnippet (normalized).
+    /// </summary>
+    /// <remarks>
+    /// We intentionally exclude line number from the hash so that if code moves
+    /// around in the file, it's still recognized as the same baselined detection.
+    /// </remarks>
+    [JsonPropertyName("hash")]
+    public required string Hash { get; init; }
+
+    /// <summary>
+    /// The rule ID that produced this detection (e.g., "SW001").
+    /// </summary>
+    [JsonPropertyName("ruleId")]
+    public required string RuleId { get; init; }
+
+    /// <summary>
+    /// Relative file path from the repository root.
+    /// </summary>
+    [JsonPropertyName("filePath")]
+    public required string FilePath { get; init; }
+
+    /// <summary>
+    /// The original line number when baselined (for reference only, not used in matching).
+    /// </summary>
+    [JsonPropertyName("lineNumber")]
+    public int LineNumber { get; init; }
+
+    /// <summary>
+    /// Normalized code snippet that triggered the detection.
+    /// </summary>
+    [JsonPropertyName("codeSnippet")]
+    public required string CodeSnippet { get; init; }
+
+    /// <summary>
+    /// The original message from the detection.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+
+    /// <summary>
+    /// When this entry was added to the baseline.
+    /// </summary>
+    [JsonPropertyName("baselinedAt")]
+    public DateTimeOffset BaselinedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Computes a stable hash for a detection result.
+    /// </summary>
+    /// <param name="ruleId">The rule ID</param>
+    /// <param name="relativePath">Relative file path</param>
+    /// <param name="codeSnippet">The code that triggered the detection</param>
+    /// <returns>A stable SHA256 hash (first 16 chars)</returns>
+    public static string ComputeHash(string ruleId, string relativePath, string codeSnippet)
+    {
+        // Normalize the code snippet: trim whitespace, normalize line endings
+        var normalizedSnippet = NormalizeCodeSnippet(codeSnippet);
+
+        // Normalize path separators
+        var normalizedPath = relativePath.Replace('\\', '/');
+
+        var input = $"{ruleId}|{normalizedPath}|{normalizedSnippet}";
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hashBytes = SHA256.HashData(bytes);
+
+        // Return first 16 chars of hex string for readability
+        return Convert.ToHexString(hashBytes)[..16].ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Normalizes a code snippet for stable hashing.
+    /// </summary>
+    private static string NormalizeCodeSnippet(string snippet)
+    {
+        if (string.IsNullOrEmpty(snippet))
+            return string.Empty;
+
+        // Normalize line endings
+        var normalized = snippet.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        // Trim each line and rejoin
+        var lines = normalized.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => !string.IsNullOrEmpty(l));
+
+        return string.Join("\n", lines);
+    }
+}

--- a/src/Slopwatch/Baseline/BaselineFile.cs
+++ b/src/Slopwatch/Baseline/BaselineFile.cs
@@ -1,0 +1,226 @@
+// -----------------------------------------------------------------------
+// <copyright file="BaselineFile.cs" company="Petabridge, LLC">
+//     Copyright (C) 2025 - 2025 Petabridge, LLC
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Slopwatch.Detection;
+
+namespace Slopwatch.Baseline;
+
+/// <summary>
+/// Represents a baseline file containing acknowledged pre-existing detections.
+/// </summary>
+public sealed class BaselineFile
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Schema version for forward compatibility.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public int Version { get; init; } = 1;
+
+    /// <summary>
+    /// When this baseline was created.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// When this baseline was last updated.
+    /// </summary>
+    [JsonPropertyName("updatedAt")]
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Optional description of the baseline.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The baselined detection entries.
+    /// </summary>
+    [JsonPropertyName("entries")]
+    public List<BaselineEntry> Entries { get; init; } = new();
+
+    /// <summary>
+    /// Lookup set for fast hash checking.
+    /// </summary>
+    [JsonIgnore]
+    private HashSet<string>? _hashLookup;
+
+    /// <summary>
+    /// Gets the hash lookup set, building it on first access.
+    /// </summary>
+    [JsonIgnore]
+    private HashSet<string> HashLookup => _hashLookup ??= Entries.Select(e => e.Hash).ToHashSet();
+
+    /// <summary>
+    /// Checks if a detection is already in the baseline.
+    /// </summary>
+    /// <param name="ruleId">The rule ID</param>
+    /// <param name="relativePath">Relative file path</param>
+    /// <param name="codeSnippet">The code snippet</param>
+    /// <returns>True if this detection is baselined</returns>
+    public bool IsBaselined(string ruleId, string relativePath, string codeSnippet)
+    {
+        var hash = BaselineEntry.ComputeHash(ruleId, relativePath, codeSnippet);
+        return HashLookup.Contains(hash);
+    }
+
+    /// <summary>
+    /// Checks if a detection result is already in the baseline.
+    /// </summary>
+    /// <param name="result">The detection result</param>
+    /// <param name="rootDirectory">Root directory for computing relative paths</param>
+    /// <returns>True if this detection is baselined</returns>
+    public bool IsBaselined(DetectionResult result, string rootDirectory)
+    {
+        var relativePath = GetRelativePath(result.FilePath, rootDirectory);
+        return IsBaselined(result.RuleId, relativePath, result.CodeSnippet ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Adds a detection result to the baseline.
+    /// </summary>
+    /// <param name="result">The detection result to baseline</param>
+    /// <param name="rootDirectory">Root directory for computing relative paths</param>
+    /// <returns>True if added, false if already exists</returns>
+    public bool AddEntry(DetectionResult result, string rootDirectory)
+    {
+        var relativePath = GetRelativePath(result.FilePath, rootDirectory);
+        var codeSnippet = result.CodeSnippet ?? string.Empty;
+        var hash = BaselineEntry.ComputeHash(result.RuleId, relativePath, codeSnippet);
+
+        if (HashLookup.Contains(hash))
+            return false;
+
+        var entry = new BaselineEntry
+        {
+            Hash = hash,
+            RuleId = result.RuleId,
+            FilePath = relativePath,
+            LineNumber = result.LineNumber,
+            CodeSnippet = codeSnippet,
+            Message = result.Message,
+            BaselinedAt = DateTimeOffset.UtcNow
+        };
+
+        Entries.Add(entry);
+        HashLookup.Add(hash);
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Creates a baseline file from a collection of detection results.
+    /// </summary>
+    /// <param name="results">The detection results to baseline</param>
+    /// <param name="rootDirectory">Root directory for computing relative paths</param>
+    /// <param name="description">Optional description</param>
+    /// <returns>A new baseline file</returns>
+    public static BaselineFile Create(
+        IEnumerable<DetectionResult> results,
+        string rootDirectory,
+        string? description = null)
+    {
+        var baseline = new BaselineFile
+        {
+            Description = description
+        };
+
+        foreach (var result in results)
+        {
+            baseline.AddEntry(result, rootDirectory);
+        }
+
+        return baseline;
+    }
+
+    /// <summary>
+    /// Loads a baseline file from disk.
+    /// </summary>
+    /// <param name="path">Path to the baseline file</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The loaded baseline file, or null if not found</returns>
+    public static async Task<BaselineFile?> LoadAsync(string path, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(path))
+            return null;
+
+        await using var stream = File.OpenRead(path);
+        var baseline = await JsonSerializer.DeserializeAsync<BaselineFile>(stream, JsonOptions, cancellationToken);
+        return baseline;
+    }
+
+    /// <summary>
+    /// Saves this baseline file to disk.
+    /// </summary>
+    /// <param name="path">Path to save to</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public async Task SaveAsync(string path, CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, this, JsonOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Filters detection results to only those NOT in the baseline.
+    /// </summary>
+    /// <param name="results">The detection results to filter</param>
+    /// <param name="rootDirectory">Root directory for computing relative paths</param>
+    /// <returns>Only new detections not in the baseline</returns>
+    public async IAsyncEnumerable<DetectionResult> FilterNewDetectionsAsync(
+        IAsyncEnumerable<DetectionResult> results,
+        string rootDirectory)
+    {
+        await foreach (var result in results)
+        {
+            if (!IsBaselined(result, rootDirectory))
+            {
+                yield return result;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the count of entries by rule ID.
+    /// </summary>
+    /// <returns>Dictionary of rule ID to count</returns>
+    public Dictionary<string, int> GetEntriesByRule()
+    {
+        return Entries
+            .GroupBy(e => e.RuleId)
+            .ToDictionary(g => g.Key, g => g.Count());
+    }
+
+    private static string GetRelativePath(string fullPath, string rootDirectory)
+    {
+        var root = Path.GetFullPath(rootDirectory);
+        var file = Path.GetFullPath(fullPath);
+
+        if (file.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+        {
+            var relative = file[root.Length..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return relative.Replace('\\', '/');
+        }
+
+        return fullPath.Replace('\\', '/');
+    }
+}

--- a/src/Slopwatch/Slopwatch.csproj
+++ b/src/Slopwatch/Slopwatch.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>

--- a/tests/Slopwatch.Tests/Baseline/BaselineFileTests.cs
+++ b/tests/Slopwatch.Tests/Baseline/BaselineFileTests.cs
@@ -1,0 +1,295 @@
+using Slopwatch.Baseline;
+using Slopwatch.Detection;
+using Xunit;
+
+namespace Slopwatch.Tests.Baseline;
+
+public class BaselineFileTests
+{
+    private static DetectionResult CreateResult(
+        string ruleId,
+        string filePath,
+        int lineNumber,
+        string? codeSnippet = null,
+        string message = "Test message")
+    {
+        return new DetectionResult(
+            RuleId: ruleId,
+            RuleName: "Test Rule",
+            Severity: DetectionSeverity.Warning,
+            FilePath: filePath,
+            LineNumber: lineNumber,
+            Column: 1,
+            Message: message,
+            CodeSnippet: codeSnippet);
+    }
+
+    [Fact]
+    public void ComputeHash_SameInput_ProducesSameHash()
+    {
+        var hash1 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "[Fact(Skip = \"test\")]");
+        var hash2 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "[Fact(Skip = \"test\")]");
+
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void ComputeHash_DifferentRuleId_ProducesDifferentHash()
+    {
+        var hash1 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "[Fact(Skip = \"test\")]");
+        var hash2 = BaselineEntry.ComputeHash("SW002", "src/Test.cs", "[Fact(Skip = \"test\")]");
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void ComputeHash_DifferentFilePath_ProducesDifferentHash()
+    {
+        var hash1 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "[Fact(Skip = \"test\")]");
+        var hash2 = BaselineEntry.ComputeHash("SW001", "src/Other.cs", "[Fact(Skip = \"test\")]");
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void ComputeHash_DifferentCodeSnippet_ProducesDifferentHash()
+    {
+        var hash1 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "[Fact(Skip = \"test\")]");
+        var hash2 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "[Fact(Skip = \"other\")]");
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void ComputeHash_NormalizesWhitespace()
+    {
+        var hash1 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "  [Fact(Skip = \"test\")]  ");
+        var hash2 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "[Fact(Skip = \"test\")]");
+
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void ComputeHash_NormalizesLineEndings()
+    {
+        var hash1 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "line1\r\nline2");
+        var hash2 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "line1\nline2");
+
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void ComputeHash_NormalizesPathSeparators()
+    {
+        var hash1 = BaselineEntry.ComputeHash("SW001", "src\\Test.cs", "code");
+        var hash2 = BaselineEntry.ComputeHash("SW001", "src/Test.cs", "code");
+
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void IsBaselined_ReturnsTrueForMatchingEntry()
+    {
+        var baseline = new BaselineFile();
+        var result = CreateResult("SW001", "/root/src/Test.cs", 10, "[Fact(Skip = \"test\")]");
+
+        baseline.AddEntry(result, "/root");
+
+        Assert.True(baseline.IsBaselined("SW001", "src/Test.cs", "[Fact(Skip = \"test\")]"));
+    }
+
+    [Fact]
+    public void IsBaselined_ReturnsFalseForNonMatchingEntry()
+    {
+        var baseline = new BaselineFile();
+        var result = CreateResult("SW001", "/root/src/Test.cs", 10, "[Fact(Skip = \"test\")]");
+
+        baseline.AddEntry(result, "/root");
+
+        Assert.False(baseline.IsBaselined("SW002", "src/Test.cs", "[Fact(Skip = \"test\")]"));
+    }
+
+    [Fact]
+    public void IsBaselined_WithDetectionResult_MatchesCorrectly()
+    {
+        var baseline = new BaselineFile();
+        var result = CreateResult("SW001", "/root/src/Test.cs", 10, "[Fact(Skip = \"test\")]");
+
+        baseline.AddEntry(result, "/root");
+
+        Assert.True(baseline.IsBaselined(result, "/root"));
+    }
+
+    [Fact]
+    public void AddEntry_ReturnsTrue_WhenNewEntry()
+    {
+        var baseline = new BaselineFile();
+        var result = CreateResult("SW001", "/root/src/Test.cs", 10, "[Fact(Skip = \"test\")]");
+
+        var added = baseline.AddEntry(result, "/root");
+
+        Assert.True(added);
+        Assert.Single(baseline.Entries);
+    }
+
+    [Fact]
+    public void AddEntry_ReturnsFalse_WhenDuplicateEntry()
+    {
+        var baseline = new BaselineFile();
+        var result = CreateResult("SW001", "/root/src/Test.cs", 10, "[Fact(Skip = \"test\")]");
+
+        baseline.AddEntry(result, "/root");
+        var added = baseline.AddEntry(result, "/root");
+
+        Assert.False(added);
+        Assert.Single(baseline.Entries);
+    }
+
+    [Fact]
+    public void AddEntry_IgnoresLineNumber_ForDuplicateDetection()
+    {
+        var baseline = new BaselineFile();
+        var result1 = CreateResult("SW001", "/root/src/Test.cs", 10, "[Fact(Skip = \"test\")]");
+        var result2 = CreateResult("SW001", "/root/src/Test.cs", 20, "[Fact(Skip = \"test\")]");
+
+        baseline.AddEntry(result1, "/root");
+        var added = baseline.AddEntry(result2, "/root");
+
+        // Same code, same file, same rule = duplicate (line number doesn't matter)
+        Assert.False(added);
+        Assert.Single(baseline.Entries);
+    }
+
+    [Fact]
+    public void Create_CreatesBaselineFromResults()
+    {
+        var results = new[]
+        {
+            CreateResult("SW001", "/root/src/Test1.cs", 10, "code1"),
+            CreateResult("SW002", "/root/src/Test2.cs", 20, "code2"),
+            CreateResult("SW001", "/root/src/Test3.cs", 30, "code3")
+        };
+
+        var baseline = BaselineFile.Create(results, "/root", "Test baseline");
+
+        Assert.Equal(3, baseline.Entries.Count);
+        Assert.Equal("Test baseline", baseline.Description);
+    }
+
+    [Fact]
+    public void GetEntriesByRule_GroupsCorrectly()
+    {
+        var results = new[]
+        {
+            CreateResult("SW001", "/root/src/Test1.cs", 10, "code1"),
+            CreateResult("SW002", "/root/src/Test2.cs", 20, "code2"),
+            CreateResult("SW001", "/root/src/Test3.cs", 30, "code3")
+        };
+
+        var baseline = BaselineFile.Create(results, "/root");
+
+        var byRule = baseline.GetEntriesByRule();
+
+        Assert.Equal(2, byRule["SW001"]);
+        Assert.Equal(1, byRule["SW002"]);
+    }
+
+    [Fact]
+    public async Task FilterNewDetectionsAsync_FiltersBaselinedResults()
+    {
+        var baselinedResults = new[]
+        {
+            CreateResult("SW001", "/root/src/Test1.cs", 10, "code1"),
+            CreateResult("SW002", "/root/src/Test2.cs", 20, "code2")
+        };
+        var baseline = BaselineFile.Create(baselinedResults, "/root");
+
+        var allResults = new[]
+        {
+            CreateResult("SW001", "/root/src/Test1.cs", 10, "code1"),  // baselined
+            CreateResult("SW002", "/root/src/Test2.cs", 20, "code2"),  // baselined
+            CreateResult("SW003", "/root/src/Test3.cs", 30, "code3")   // new
+        };
+
+        var filtered = new List<DetectionResult>();
+        await foreach (var result in baseline.FilterNewDetectionsAsync(ToAsyncEnumerable(allResults), "/root"))
+        {
+            filtered.Add(result);
+        }
+
+        Assert.Single(filtered);
+        Assert.Equal("SW003", filtered[0].RuleId);
+    }
+
+    [Fact]
+    public async Task SaveAsync_And_LoadAsync_RoundTrips()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"slopwatch-test-{Guid.NewGuid()}.json");
+        try
+        {
+            var results = new[]
+            {
+                CreateResult("SW001", "/root/src/Test.cs", 10, "code1"),
+                CreateResult("SW002", "/root/src/Other.cs", 20, "code2")
+            };
+            var original = BaselineFile.Create(results, "/root", "Test baseline");
+
+            await original.SaveAsync(tempPath);
+            var loaded = await BaselineFile.LoadAsync(tempPath);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(original.Entries.Count, loaded.Entries.Count);
+            Assert.Equal(original.Description, loaded.Description);
+            Assert.Equal(original.Version, loaded.Version);
+
+            // Verify entries match
+            for (int i = 0; i < original.Entries.Count; i++)
+            {
+                Assert.Equal(original.Entries[i].Hash, loaded.Entries[i].Hash);
+                Assert.Equal(original.Entries[i].RuleId, loaded.Entries[i].RuleId);
+                Assert.Equal(original.Entries[i].FilePath, loaded.Entries[i].FilePath);
+            }
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReturnsNull_WhenFileNotFound()
+    {
+        var result = await BaselineFile.LoadAsync("/nonexistent/path/baseline.json");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void IsBaselined_HandlesNullCodeSnippet()
+    {
+        var baseline = new BaselineFile();
+        var result = CreateResult("SW001", "/root/src/Test.cs", 10, codeSnippet: null);
+
+        baseline.AddEntry(result, "/root");
+
+        Assert.True(baseline.IsBaselined(result, "/root"));
+    }
+
+    [Fact]
+    public void Create_HandlesEmptyResults()
+    {
+        var baseline = BaselineFile.Create(Array.Empty<DetectionResult>(), "/root");
+
+        Assert.Empty(baseline.Entries);
+    }
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item;
+        }
+        await Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `slopwatch init` command for easy project onboarding
- Baseline is **required by default** - ensures we only catch new slop
- Add `--no-baseline` flag for one-off full analysis
- Add `--create-baseline` and `--update-baseline` options
- Remove unused LibGit2Sharp dependency (baseline approach doesn't need git)

## How It Works

1. Run `slopwatch init` to create `.slopwatch/baseline.json` from existing code
2. Commit the baseline to your repository
3. Future `slopwatch analyze` runs only report NEW detections
4. CI/CD fails if new slop is introduced

## Test Plan

- [x] 20 new unit tests for baseline functionality
- [x] All 147 tests passing
- [x] Manual testing of init and analyze commands