### PR TITLE
Update copyright to Aaron Stannard and configure library NuGet

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2025-$([System.DateTime]::Now.Year) Stannard Labs</Copyright>
+    <Copyright>Copyright © 2025-$([System.DateTime]::Now.Year) Aaron Stannard</Copyright>
     <Authors>Aaron Stannard</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>latest</LangVersion>

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2013-2025 .NET Foundation
+   Copyright 2025 Aaron Stannard
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/Slopwatch/Baseline/BaselineEntry.cs
+++ b/src/Slopwatch/Baseline/BaselineEntry.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
-// <copyright file="BaselineEntry.cs" company="Petabridge, LLC">
-//     Copyright (C) 2025 - 2025 Petabridge, LLC
+// <copyright file="BaselineEntry.cs" company="Aaron Stannard">
+//     Copyright (C) 2025 - 2025 Aaron Stannard
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Slopwatch/Baseline/BaselineFile.cs
+++ b/src/Slopwatch/Baseline/BaselineFile.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
-// <copyright file="BaselineFile.cs" company="Petabridge, LLC">
-//     Copyright (C) 2025 - 2025 Petabridge, LLC
+// <copyright file="BaselineFile.cs" company="Aaron Stannard">
+//     Copyright (C) 2025 - 2025 Aaron Stannard
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Slopwatch/Slopwatch.csproj
+++ b/src/Slopwatch/Slopwatch.csproj
@@ -4,7 +4,11 @@
     <TargetFramework>$(NetCoreVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Description>Core library for detecting LLM-generated "sloppy" code patterns in .NET projects</Description>
+    <Description>Core library for detecting LLM-generated "sloppy" code patterns in .NET projects. Use this library to build custom detection rules, IDE extensions, or integrate slopwatch into your own analysis pipelines.</Description>
+
+    <!-- NuGet package configuration -->
+    <IsPackable>true</IsPackable>
+    <PackageId>Slopwatch</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Update LICENSE copyright from ".NET Foundation" to "Aaron Stannard"
- Update Directory.Build.props copyright to "Aaron Stannard"
- Update source file headers from "Petabridge, LLC" to "Aaron Stannard"
- Configure `Slopwatch` library for NuGet publishing

## NuGet Packages

After this PR, two packages will be published:

| Package | Type | Description |
|---------|------|-------------|
| `Slopwatch` | Library | Core detection rules, FileAnalyzer, BaselineFile - for building custom integrations |
| `Slopwatch.Cmd` | dotnet tool | CLI tool (`slopwatch` command) |

## Test Plan

- [x] All 147 tests passing
- [x] Build succeeds