### PR TITLE
Add --stats flag for analysis performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ slopwatch analyze --fail-on error
 slopwatch analyze --fail-on warning
 ```
 
+### Performance
+
+If you're concerned about performance on large projects, use `--stats` to see how many files are being analyzed and how long it takes:
+
+```bash
+slopwatch analyze --stats
+# Output: Stats: 44 files analyzed in 1.64s
+```
+
 ## Detection Rules
 
 | Rule | Severity | Description |

--- a/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CommandLine;
 using Slopwatch.Analysis;
 using Slopwatch.Baseline;
@@ -55,12 +56,18 @@ public sealed class AnalyzeCommand
     [Option("hook", HelpText = "Hook mode for Claude Code integration: outputs errors to stderr, suppresses other output, fails on warnings by default, exits with code 2 on failure")]
     public bool HookMode { get; set; }
 
+    [Option("stats", HelpText = "Show analysis statistics (files analyzed, time elapsed)")]
+    public bool ShowStats { get; set; }
+
     /// <summary>
     /// Executes the analyze command.
     /// </summary>
     /// <returns>Exit code: 0 = success, 1 = issues found (normal mode), 2 = issues found (hook mode) or error</returns>
     public async Task<int> ExecuteAsync(CancellationToken cancellationToken = default)
     {
+        var stopwatch = ShowStats ? Stopwatch.StartNew() : null;
+        var filesAnalyzed = 0;
+
         try
         {
             // Validate mutually exclusive options
@@ -172,6 +179,7 @@ public sealed class AnalyzeCommand
                     }
                 }
 
+                filesAnalyzed = filePaths.Count;
                 results = analyzer.AnalyzeFilesAsync(filePaths, cancellationToken);
             }
             else
@@ -185,7 +193,18 @@ public sealed class AnalyzeCommand
 
                 // CommandLineParser initializes IEnumerable to empty (not null), so check Any()
                 var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj" };
-                results = analyzer.AnalyzeDirectoryAsync(rootDirectory, patterns, cancellationToken);
+
+                // For stats, we need to enumerate files first to get count
+                if (ShowStats)
+                {
+                    var fileList = analyzer.GetMatchingFiles(rootDirectory, patterns).ToList();
+                    filesAnalyzed = fileList.Count;
+                    results = analyzer.AnalyzeFilesAsync(fileList, cancellationToken);
+                }
+                else
+                {
+                    results = analyzer.AnalyzeDirectoryAsync(rootDirectory, patterns, cancellationToken);
+                }
             }
 
             // Handle --create-baseline mode
@@ -224,6 +243,14 @@ public sealed class AnalyzeCommand
 
             // Format and output results
             await formatter.FormatAsync(trackedResults, Console.Out, cancellationToken);
+
+            // Output stats if requested
+            if (ShowStats && stopwatch is not null)
+            {
+                stopwatch.Stop();
+                await Console.Error.WriteLineAsync();
+                await Console.Error.WriteLineAsync($"Stats: {filesAnalyzed} files analyzed in {stopwatch.Elapsed.TotalSeconds:F2}s");
+            }
 
             // Determine exit code (1 = issues found in normal mode)
             return issueTracker.ShouldFail ? 1 : 0;

--- a/src/Slopwatch/Analysis/FileAnalyzer.cs
+++ b/src/Slopwatch/Analysis/FileAnalyzer.cs
@@ -155,7 +155,7 @@ public sealed class FileAnalyzer
     /// <param name="directoryPath">The directory to search.</param>
     /// <param name="patterns">The glob patterns to match.</param>
     /// <returns>A collection of matching file paths.</returns>
-    private IEnumerable<string> GetMatchingFiles(string directoryPath, string[] patterns)
+    public IEnumerable<string> GetMatchingFiles(string directoryPath, string[] patterns)
     {
         var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
## Summary
Adds `--stats` flag to show analysis performance metrics - useful for understanding performance on large projects.

## Usage
```bash
slopwatch analyze -d . --stats
```

Output:
```
Scan complete: 0 issue(s) found

Stats: 44 files analyzed in 1.64s
```

## Changes
- Add `--stats` option to AnalyzeCommand
- Make `GetMatchingFiles` public in FileAnalyzer for accurate file counting
- Stats output to stderr (doesn't interfere with JSON output)

## Test plan
- [x] Build succeeds
- [x] All 147 tests pass
- [x] `--stats` shows correct file count and timing