### PR TITLE
Add --stats to CI and RollForward for .NET compatibility

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -69,4 +69,4 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           # Check current directory for slop patterns (dogfooding)
-          slopwatch analyze -d . --fail-on error
+          slopwatch analyze -d . --fail-on error --stats

--- a/src/Slopwatch.Cmd/Slopwatch.Cmd.csproj
+++ b/src/Slopwatch.Cmd/Slopwatch.Cmd.csproj
@@ -10,6 +10,9 @@
     <!-- dotnet tool configuration -->
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>slopwatch</ToolCommandName>
+
+    <!-- Allow running on newer .NET versions (e.g., .NET 10 when built for .NET 9) -->
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add `--stats` flag to slopwatch dogfood step in PR validation CI
- Add `RollForward=LatestMajor` to allow tool to run on newer .NET versions (e.g., .NET 10 when built for .NET 9)

## Test plan
- [x] Build succeeds
- [x] All 147 tests pass