### PR TITLE
Remove overly broad exception type check from SW003

### DIFF
--- a/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
+++ b/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
@@ -7,7 +7,7 @@ using Slopwatch.Suppression;
 namespace Slopwatch.Detection.Rules;
 
 /// <summary>
-/// Detects empty or overly broad catch blocks that swallow exceptions.
+/// Detects empty catch blocks that swallow exceptions.
 /// Rule ID: SW003
 /// </summary>
 /// <remarks>
@@ -16,7 +16,6 @@ namespace Slopwatch.Detection.Rules;
 /// <item><description>Are completely empty</description></item>
 /// <item><description>Only contain comments</description></item>
 /// <item><description>Only log without rethrowing or handling</description></item>
-/// <item><description>Use overly broad exception types (catch(Exception) or catch with no type)</description></item>
 /// </list>
 ///
 /// Empty catch blocks often indicate:
@@ -26,6 +25,10 @@ namespace Slopwatch.Detection.Rules;
 /// <item><description>Lazy exception handling that should be improved</description></item>
 /// <item><description>Security issues being hidden</description></item>
 /// </list>
+///
+/// Note: This rule does NOT flag catch blocks that catch broad exception types (like Exception)
+/// as long as they contain actual handling code. Catching Exception is a legitimate pattern
+/// for top-level handlers, plugin systems, and graceful degradation scenarios.
 ///
 /// This rule can be suppressed with <see cref="SlopwatchSuppressAttribute"/> when there's
 /// a legitimate reason for an empty catch block (e.g., optional configuration files, benign exceptions).
@@ -40,7 +43,7 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
 
     /// <inheritdoc />
     public string Description =>
-        "Detects empty or overly broad catch blocks that swallow exceptions without proper handling. " +
+        "Detects empty catch blocks that swallow exceptions without proper handling. " +
         "Exceptions should be handled appropriately or allowed to propagate.";
 
     /// <inheritdoc />
@@ -114,24 +117,6 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
                     GetCatchSnippet(catchClause),
                     "Consider rethrowing the exception or handling it appropriately"
                 );
-                continue;
-            }
-
-            // Check for overly broad exception types
-            if (IsOverlyBroadCatch(catchClause))
-            {
-                var exceptionType = GetExceptionType(catchClause);
-                yield return new DetectionResult(
-                    RuleId,
-                    Name,
-                    DetectionSeverity.Warning, // Lower severity for broad catches
-                    context.FilePath,
-                    lineNumber,
-                    location.StartLinePosition.Character + 1,
-                    $"Catch block uses overly broad exception type: {exceptionType}",
-                    GetCatchSnippet(catchClause),
-                    "Consider catching specific exception types instead of broad Exception"
-                );
             }
         }
     }
@@ -199,33 +184,6 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
 
         // Only flag if it's logging only without rethrow or other handling
         return hasLogging && !hasRethrow && !hasOtherStatements;
-    }
-
-    /// <summary>
-    /// Checks if catch block uses overly broad exception types
-    /// </summary>
-    private static bool IsOverlyBroadCatch(CatchClauseSyntax catchClause)
-    {
-        // catch without type specification catches everything
-        if (catchClause.Declaration is null)
-            return true;
-
-        var exceptionType = catchClause.Declaration.Type.ToString();
-
-        // Check for System.Exception or just Exception
-        return exceptionType == "Exception" ||
-               exceptionType == "System.Exception";
-    }
-
-    /// <summary>
-    /// Gets the exception type being caught
-    /// </summary>
-    private static string GetExceptionType(CatchClauseSyntax catchClause)
-    {
-        if (catchClause.Declaration is null)
-            return "all exceptions";
-
-        return catchClause.Declaration.Type.ToString();
     }
 
     /// <summary>

--- a/tests/Slopwatch.Tests.Fixtures/EmptyCatchSamples.cs
+++ b/tests/Slopwatch.Tests.Fixtures/EmptyCatchSamples.cs
@@ -74,9 +74,9 @@ public class EmptyCatchSamples
         }
     }
 
-    // SHOULD TRIGGER: SW003 (Warning severity)
-    // Overly broad catch - catches all exceptions
-    public void BroadExceptionCatch_ShouldTrigger()
+    // SHOULD NOT TRIGGER (has actual handling)
+    // Broad exception catch with actual handling is legitimate
+    public void BroadExceptionCatch_WithHandling_ShouldNotTrigger()
     {
         try
         {
@@ -85,15 +85,14 @@ public class EmptyCatchSamples
         }
         catch (Exception)
         {
-            // Catching System.Exception is too broad
-            // Should catch specific exceptions
+            // Has actual handling code - this is legitimate for top-level handlers
             Console.WriteLine("Something went wrong");
         }
     }
 
-    // SHOULD TRIGGER: SW003 (Warning severity)
-    // Catch without type specification (catches everything)
-    public void CatchAllExceptions_ShouldTrigger()
+    // SHOULD NOT TRIGGER (has actual handling)
+    // Catch without type but with actual handling
+    public void CatchAll_WithHandling_ShouldNotTrigger()
     {
         try
         {
@@ -101,7 +100,7 @@ public class EmptyCatchSamples
         }
         catch
         {
-            // Catches absolutely everything, even non-CLR exceptions
+            // Has actual handling code
             Debug.WriteLine("Error suppressed");
         }
     }

--- a/tests/Slopwatch.Tests.Fixtures/README.md
+++ b/tests/Slopwatch.Tests.Fixtures/README.md
@@ -39,8 +39,7 @@ Contains examples of:
 - Completely empty `catch` blocks
 - Catch blocks with only comments
 - Catch blocks that only log without rethrowing
-- Overly broad exception catches (`catch(Exception)`, `catch` without type)
-- Proper exception handling patterns
+- Proper exception handling patterns (including `catch(Exception)` with actual handling)
 - Valid suppressions for optional configuration files and cleanup code
 
 ### TimeoutJigglingSamples.cs

--- a/tests/Slopwatch.Tests/Detection/EmptyCatchBlockRuleTests.cs
+++ b/tests/Slopwatch.Tests/Detection/EmptyCatchBlockRuleTests.cs
@@ -146,9 +146,9 @@ public class TestClass
     }
 
     [Fact]
-    public void Test_DetectsBroadCatchException()
+    public void Test_IgnoresBroadCatchWithHandling()
     {
-        // Arrange
+        // Arrange - catch(Exception) with actual handling is legitimate
         const string code = @"
 public class TestClass
 {
@@ -172,18 +172,15 @@ public class TestClass
         // Act
         var results = RunRule(context);
 
-        // Assert
-        var result = Assert.Single(results);
-        Assert.Equal("SW003", result.RuleId);
-        Assert.Contains("overly broad exception type", result.Message);
-        Assert.Contains("Exception", result.Message);
-        Assert.Equal(DetectionSeverity.Warning, result.Severity);
+        // Assert - Catching Exception with actual handling code is NOT flagged
+        // This is a legitimate pattern for top-level handlers, plugin systems, etc.
+        Assert.Empty(results);
     }
 
     [Fact]
-    public void Test_DetectsCatchWithoutType()
+    public void Test_IgnoresCatchWithoutTypeButWithHandling()
     {
-        // Arrange
+        // Arrange - catch without type but with actual handling is legitimate
         const string code = @"
 public class TestClass
 {
@@ -207,11 +204,8 @@ public class TestClass
         // Act
         var results = RunRule(context);
 
-        // Assert
-        var result = Assert.Single(results);
-        Assert.Equal("SW003", result.RuleId);
-        Assert.Contains("overly broad exception type", result.Message);
-        Assert.Contains("all exceptions", result.Message);
+        // Assert - bare catch with actual handling code is NOT flagged
+        Assert.Empty(results);
     }
 
     [Fact]
@@ -427,9 +421,9 @@ public class TestClass
     }
 
     [Fact]
-    public void Test_DetectsSystemException()
+    public void Test_IgnoresSystemExceptionWithHandling()
     {
-        // Arrange
+        // Arrange - System.Exception with actual handling is legitimate
         const string code = @"
 public class TestClass
 {
@@ -453,16 +447,14 @@ public class TestClass
         // Act
         var results = RunRule(context);
 
-        // Assert
-        var result = Assert.Single(results);
-        Assert.Equal("SW003", result.RuleId);
-        Assert.Contains("overly broad", result.Message);
+        // Assert - System.Exception with actual handling code is NOT flagged
+        Assert.Empty(results);
     }
 
     [Fact]
     public void Test_IgnoresCatchWithOtherStatements()
     {
-        // Arrange
+        // Arrange - catch with logging AND other statements is proper handling
         const string code = @"
 public class TestClass
 {
@@ -488,11 +480,9 @@ public class TestClass
         // Act
         var results = RunRule(context);
 
-        // Assert
-        // Should still detect broad Exception type, but not as logging-only
-        var result = Assert.Single(results);
-        Assert.DoesNotContain("only logs", result.Message);
-        Assert.Contains("overly broad", result.Message);
+        // Assert - catch with logging + other handling is NOT flagged
+        // The rule only flags empty catches and logging-only catches (without rethrow)
+        Assert.Empty(results);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Removes the "overly broad exception type" check from the SW003 rule. The rule now only flags:

- Empty catch blocks (Error severity)
- Catch blocks with only comments (Error severity)  
- Catch blocks that only log without rethrowing (Warning severity)

It **no longer flags** `catch(Exception)` or `catch` without type when there is actual handling code present.

## Reasoning

The purpose of slopwatch is to detect LLM "reward hacking" behaviors - shortcuts that make tests pass without actually solving problems. Empty catch blocks are a clear example of this: they silently swallow exceptions, hiding real problems.

However, catching `Exception` with actual handling code is a legitimate pattern for:
- Top-level exception handlers
- Plugin/extension systems
- Graceful degradation
- Async exception handlers on thread pool threads

The key distinction is:
- **Empty catch blocks = slop** - The LLM is avoiding the problem
- **catch(Exception) with handling = legitimate code** - A conscious design choice

## Changes

- Updated `EmptyCatchBlockRule.cs` to remove `IsOverlyBroadCatch` method and its usage
- Updated docstrings to clarify the rule only flags empty catches
- Updated tests to verify the new behavior
- Updated test fixtures and documentation

Fixes #17

## Test plan

- [ ] All existing unit tests pass (147 tests)
- [ ] New tests verify catch(Exception) with handling is NOT flagged
- [ ] CI validation passes