### PR TITLE
Exclude git worktrees from analysis by default

### DIFF
--- a/src/Slopwatch/Analysis/AnalysisOptions.cs
+++ b/src/Slopwatch/Analysis/AnalysisOptions.cs
@@ -51,7 +51,9 @@ public sealed class AnalysisOptions
         "**/*.Designer.cs",
         "**/*.generated.cs",
         "**/*.g.cs",
-        "**/*.g.i.cs"
+        "**/*.g.i.cs",
+        // Git worktrees - avoid analyzing the same code multiple times
+        "**/worktrees/**"
     };
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds `**/worktrees/**` to the default exclusion patterns to prevent slopwatch from analyzing the same code multiple times when git worktrees are present.

## Problem

When a repository contains git worktrees (e.g., in a `worktrees/` directory), slopwatch would analyze the same codebase multiple times - once for the main checkout and once for each worktree. This causes:

- Duplicate detections in results
- Bloated baseline files (observed ~2000 duplicate entries in Akka.NET)
- Slower analysis times

## Solution

Add `**/worktrees/**` to the default `ExcludePatterns` in `AnalysisOptions.cs`.

## Test plan

- [x] All unit tests pass
- [x] Build succeeds