### PR TITLE
Fix hook mode not triggering git status optimization

### DIFF
--- a/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
@@ -165,7 +165,7 @@ public sealed class AnalyzeCommand
             IAsyncEnumerable<DetectionResult> results;
 
             // In hook mode, only analyze dirty files from git status (much faster)
-            if (HookMode && Files is null)
+            if (HookMode && !(Files?.Any() == true))
             {
                 var dirtyFiles = await GetDirtyFilesAsync(rootDirectory, cancellationToken);
 
@@ -176,7 +176,6 @@ public sealed class AnalyzeCommand
                 }
 
                 // Filter to only supported file types
-                var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj" };
                 var supportedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".cs", ".csproj" };
                 var filesToAnalyze = dirtyFiles
                     .Where(f => supportedExtensions.Contains(Path.GetExtension(f)))


### PR DESCRIPTION
## Summary
- Fixed bug where hook mode wasn't using git status optimization
- CommandLineParser initializes `IEnumerable` options to empty collections, not null
- Changed condition from `Files is null` to `!(Files?.Any() == true)`
- Removed unused `patterns` variable

## Test plan
- [x] Unit tests pass (147/147)
- [x] Manual testing on Akka.NET repo: hook mode now takes ~340ms instead of ~16s