### PR TITLE
Include .props and .targets in default file patterns

### DIFF
--- a/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
@@ -179,7 +179,7 @@ public sealed class AnalyzeCommand
                 }
 
                 // Filter to only supported file types
-                var supportedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".cs", ".csproj" };
+                var supportedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".cs", ".csproj", ".props", ".targets" };
                 var filesToAnalyze = dirtyFiles
                     .Where(f => supportedExtensions.Contains(Path.GetExtension(f)))
                     .Where(File.Exists) // Skip deleted files
@@ -221,7 +221,7 @@ public sealed class AnalyzeCommand
                 }
 
                 // CommandLineParser initializes IEnumerable to empty (not null), so check Any()
-                var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj" };
+                var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj", "**/*.props", "**/*.targets" };
 
                 // Get the list of files to analyze
                 var fileList = analyzer.GetMatchingFiles(rootDirectory, patterns).ToList();


### PR DESCRIPTION
## Summary
Previously only `.cs` and `.csproj` files were analyzed by default, meaning `Directory.Build.props` and similar MSBuild files were not scanned unless explicitly specified with `-f` flag.

Now SW005 (project file slop) can catch warning suppression in:
- `Directory.Build.props`
- `Directory.Build.targets`
- Any custom `.props`/`.targets` files

Updated both directory analysis and hook mode file filtering.

## Test plan
- [x] Unit tests pass (147/147)
- [x] Verified on Akka.NET repo: `Directory.Build.props` now detected during `slopwatch analyze -d .`