### PR TITLE
Add SW006 rule to detect CPM version override abuse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ tests/
 - **SW002**: Warning suppression (`#pragma warning disable`, `[SuppressMessage]`)
 - **SW003**: Empty catch blocks (swallowing exceptions)
 - **SW004**: Timeout jiggling (`Task.Delay`, `Thread.Sleep` in tests)
-- Additional rules to be discovered through research
+- **SW005**: Project file slop (`TreatWarningsAsErrors=false`, `NoWarn`, `Nullable=disable`)
+- **SW006**: CPM version override abuse (`VersionOverride`, `Version` when CPM enabled)
 
 ## Development Guidelines
 
@@ -79,6 +80,7 @@ If you see "SLOPWATCH BLOCKED" in a hook error, your edit introduced a "reward h
 - **SW003**: Don't use empty catch blocks that swallow exceptions
 - **SW004**: Don't add arbitrary delays (`Task.Delay`, `Thread.Sleep`) in tests
 - **SW005**: Don't disable `TreatWarningsAsErrors` or add to `NoWarn`
+- **SW006**: Don't bypass CPM with `VersionOverride` or inline `Version` attributes; update `Directory.Packages.props` instead
 
 **How to fix**: Read the specific error message and suggested fix. Implement a proper solution instead of working around the problem. If the suppression is genuinely needed, use `[SlopwatchSuppress("SW###", "justification with 20+ chars")]`.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ When LLMs generate code, they sometimes take shortcuts that make tests pass or b
 - **Swallowing exceptions** with empty catch blocks
 - **Adding arbitrary delays** to mask timing issues (`Task.Delay(1000)`)
 - **Project-level warning suppression** (`<NoWarn>`, `<TreatWarningsAsErrors>false</TreatWarningsAsErrors>`)
+- **Bypassing Central Package Management** with `VersionOverride` or inline `Version` attributes
 - And more...
 
 Slopwatch catches these patterns before they make it into your codebase.
@@ -135,6 +136,7 @@ slopwatch analyze --stats
 | SW003 | Error | Empty catch blocks that swallow exceptions |
 | SW004 | Warning | Arbitrary delays in test code (Task.Delay, Thread.Sleep) |
 | SW005 | Warning | Project file slop (NoWarn, TreatWarningsAsErrors=false) |
+| SW006 | Warning | CPM bypass via VersionOverride or inline Version attributes |
 
 ## Claude Code Integration
 
@@ -207,7 +209,9 @@ Create a `.slopwatch/slopwatch.json` configuration file to customize behavior:
     "SW001": { "enabled": true, "severity": "error" },
     "SW002": { "enabled": true, "severity": "warning" },
     "SW003": { "enabled": true, "severity": "error" },
-    "SW004": { "enabled": true, "severity": "warning" }
+    "SW004": { "enabled": true, "severity": "warning" },
+    "SW005": { "enabled": true, "severity": "warning" },
+    "SW006": { "enabled": true, "severity": "warning" }
   },
   "exclude": ["**/Generated/**", "**/obj/**", "**/bin/**"]
 }

--- a/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
@@ -425,6 +425,7 @@ public sealed class AnalyzeCommand
         yield return new EmptyCatchBlockRule();
         yield return new TimeoutJigglingRule();
         yield return new ProjectFileRule();
+        yield return new PackageVersionOverrideRule();
     }
 
     private IOutputFormatter CreateOutputFormatter()

--- a/src/Slopwatch.Cmd/Commands/InitCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/InitCommand.cs
@@ -160,6 +160,7 @@ public sealed class InitCommand
         yield return new EmptyCatchBlockRule();
         yield return new TimeoutJigglingRule();
         yield return new ProjectFileRule();
+        yield return new PackageVersionOverrideRule();
     }
 
     private static bool TryParseSeverity(string severityText, out DetectionSeverity severity)

--- a/src/Slopwatch.Cmd/Commands/ListRulesCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/ListRulesCommand.cs
@@ -25,7 +25,8 @@ public sealed class ListRulesCommand
                 new WarningSuppressRule(),
                 new EmptyCatchBlockRule(),
                 new TimeoutJigglingRule(),
-                new ProjectFileRule()
+                new ProjectFileRule(),
+                new PackageVersionOverrideRule()
             };
 
             Console.WriteLine("Available Detection Rules:");

--- a/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
+++ b/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
@@ -1,0 +1,356 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Slopwatch.Detection.Rules;
+
+/// <summary>
+/// Detects CPM (Central Package Management) version override abuse.
+/// Rule ID: SW006
+/// </summary>
+/// <remarks>
+/// This rule identifies problematic package version patterns:
+/// <list type="bullet">
+/// <item><description>VersionOverride attribute on PackageReference - always slop</description></item>
+/// <item><description>Version attribute on PackageReference in .csproj when CPM is enabled</description></item>
+/// </list>
+///
+/// Central Package Management is detected when:
+/// <list type="bullet">
+/// <item><description>Directory.Packages.props exists with PackageVersion elements</description></item>
+/// <item><description>ManagePackageVersionsCentrally is set to true in props files</description></item>
+/// </list>
+///
+/// This rule can be suppressed with XML comments: &lt;!-- slopwatch-ignore: SW006 justification --&gt;
+/// </remarks>
+public sealed class PackageVersionOverrideRule : IDetectionRule
+{
+    /// <inheritdoc />
+    public string RuleId => "SW006";
+
+    /// <inheritdoc />
+    public string Name => "Package Version Override Detection";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Detects CPM (Central Package Management) version override abuse including " +
+        "VersionOverride attributes (always slop) and Version attributes on PackageReference " +
+        "when Central Package Management is enabled in the repository.";
+
+    /// <inheritdoc />
+    public DetectionSeverity DefaultSeverity => DetectionSeverity.Warning;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> ApplicableFilePatterns => new[] { "*.csproj", "*.props", "*.targets" };
+
+    // Matches: <!-- slopwatch-ignore: SW006 justification text here -->
+    private static readonly Regex XmlCommentSuppressionPattern = new(
+        @"<!--\s*slopwatch-ignore\s*:\s*(SW\d{3})\s+(.+?)\s*-->",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private const int MinJustificationLength = 20;
+
+    // Cache for CPM detection results per directory
+    private static readonly ConcurrentDictionary<string, bool> CpmCache = new();
+
+    /// <summary>
+    /// Internal testing hook to override CPM detection.
+    /// When not null, this value is used instead of file system detection.
+    /// </summary>
+    internal bool? CpmEnabledOverride { get; set; }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<DetectionResult> AnalyzeAsync(
+        DetectionContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Parse XML suppressions from content
+        var suppressions = ParseXmlSuppressions(context.Content);
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(context.Content, LoadOptions.SetLineInfo);
+        }
+        catch
+        {
+            // Invalid XML - skip analysis
+            yield break;
+        }
+
+        // Skip Directory.Packages.props entirely - that's where versions belong
+        var isDirectoryPackagesProps = context.FileName.Equals("Directory.Packages.props", StringComparison.OrdinalIgnoreCase);
+
+        // Check for VersionOverride (always slop, even in Directory.Packages.props though it shouldn't be there)
+        await foreach (var result in AnalyzeVersionOverride(context, document, suppressions, cancellationToken))
+        {
+            yield return result;
+        }
+
+        // Skip Version attribute analysis for Directory.Packages.props
+        if (isDirectoryPackagesProps)
+        {
+            yield break;
+        }
+
+        // Check if CPM is enabled for Version attribute analysis
+        var cpmEnabled = CpmEnabledOverride ?? IsCpmEnabled(context.FilePath);
+
+        if (cpmEnabled)
+        {
+            await foreach (var result in AnalyzeVersionAttribute(context, document, suppressions, cancellationToken))
+            {
+                yield return result;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses XML comment suppressions from the content.
+    /// </summary>
+    private static List<(string RuleId, string Justification, int Line)> ParseXmlSuppressions(string content)
+    {
+        var suppressions = new List<(string RuleId, string Justification, int Line)>();
+        var lines = content.Split('\n');
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var match = XmlCommentSuppressionPattern.Match(line);
+
+            if (match.Success)
+            {
+                var ruleId = match.Groups[1].Value;
+                var justification = match.Groups[2].Value.Trim();
+
+                if (justification.Length >= MinJustificationLength)
+                {
+                    suppressions.Add((ruleId, justification, i + 1));
+                }
+            }
+        }
+
+        return suppressions;
+    }
+
+    /// <summary>
+    /// Checks if a specific line is suppressed.
+    /// </summary>
+    private static bool IsSuppressed(List<(string RuleId, string Justification, int Line)> suppressions, string ruleId, int lineNumber)
+    {
+        // Check if there's a suppression comment on the line immediately before
+        return suppressions.Any(s =>
+            s.RuleId.Equals(ruleId, StringComparison.OrdinalIgnoreCase) &&
+            s.Line == lineNumber - 1);
+    }
+
+    /// <summary>
+    /// Checks if Central Package Management is enabled for a given file path.
+    /// </summary>
+    private static bool IsCpmEnabled(string filePath)
+    {
+        var directory = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrEmpty(directory))
+            return false;
+
+        return CpmCache.GetOrAdd(directory, DetectCpmInDirectoryTree);
+    }
+
+    /// <summary>
+    /// Walks up the directory tree to detect CPM configuration.
+    /// </summary>
+    private static bool DetectCpmInDirectoryTree(string directory)
+    {
+        var currentDir = directory;
+
+        while (!string.IsNullOrEmpty(currentDir))
+        {
+            // Check for Directory.Packages.props
+            var packagesPropsPath = Path.Combine(currentDir, "Directory.Packages.props");
+            if (TryReadFileContent(packagesPropsPath, out var packagesContent))
+            {
+                // Check if it contains PackageVersion elements (basic heuristic)
+                if (packagesContent.Contains("<PackageVersion", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                // Also check for ManagePackageVersionsCentrally
+                if (packagesContent.Contains("<ManagePackageVersionsCentrally>true", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            // Also check Directory.Build.props for ManagePackageVersionsCentrally
+            var buildPropsPath = Path.Combine(currentDir, "Directory.Build.props");
+            if (TryReadFileContent(buildPropsPath, out var buildContent))
+            {
+                if (buildContent.Contains("<ManagePackageVersionsCentrally>true", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            currentDir = Path.GetDirectoryName(currentDir);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to read file content safely, returning false if file doesn't exist or can't be read.
+    /// </summary>
+    private static bool TryReadFileContent(string filePath, out string content)
+    {
+        content = string.Empty;
+
+        if (!File.Exists(filePath))
+            return false;
+
+        try
+        {
+            content = File.ReadAllText(filePath);
+            return true;
+        }
+        catch (IOException)
+        {
+            // File locked or inaccessible - continue searching
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // No permission to read - continue searching
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Analyzes VersionOverride attributes on PackageReference elements.
+    /// VersionOverride is always flagged as it explicitly bypasses CPM.
+    /// </summary>
+    private async IAsyncEnumerable<DetectionResult> AnalyzeVersionOverride(
+        DetectionContext context,
+        XDocument document,
+        List<(string RuleId, string Justification, int Line)> suppressions,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var packageReferences = document.Descendants()
+            .Where(e => e.Name.LocalName == "PackageReference")
+            .ToList();
+
+        foreach (var element in packageReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var versionOverrideAttr = element.Attribute("VersionOverride");
+            if (versionOverrideAttr is null)
+                continue;
+
+            var lineInfo = (IXmlLineInfo)element;
+            var lineNumber = lineInfo.HasLineInfo() ? lineInfo.LineNumber : 0;
+
+            // Skip if not in diff scope
+            if (lineNumber > 0 && !context.IsLineInScope(lineNumber))
+                continue;
+
+            // Check if suppressed
+            if (IsSuppressed(suppressions, RuleId, lineNumber))
+                continue;
+
+            var packageName = element.Attribute("Include")?.Value ??
+                              element.Attribute("Update")?.Value ??
+                              "Unknown";
+            var version = versionOverrideAttr.Value;
+
+            yield return new DetectionResult(
+                RuleId,
+                Name,
+                DetectionSeverity.Warning,
+                context.FilePath,
+                lineNumber,
+                lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
+                $"VersionOverride explicitly bypasses Central Package Management for '{packageName}' (version: {version})",
+                element.ToString(),
+                "Remove VersionOverride and use the centrally managed version in Directory.Packages.props, or add suppression comment with justification"
+            );
+        }
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Analyzes Version attributes on PackageReference elements when CPM is enabled.
+    /// </summary>
+    private async IAsyncEnumerable<DetectionResult> AnalyzeVersionAttribute(
+        DetectionContext context,
+        XDocument document,
+        List<(string RuleId, string Justification, int Line)> suppressions,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var packageReferences = document.Descendants()
+            .Where(e => e.Name.LocalName == "PackageReference")
+            .ToList();
+
+        foreach (var element in packageReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Check for Version attribute
+            var versionAttr = element.Attribute("Version");
+            // Also check for nested Version element
+            var versionElement = element.Elements()
+                .FirstOrDefault(e => e.Name.LocalName == "Version");
+
+            if (versionAttr is null && versionElement is null)
+                continue;
+
+            // Skip if it also has VersionOverride (already reported above)
+            if (element.Attribute("VersionOverride") is not null)
+                continue;
+
+            var lineInfo = (IXmlLineInfo)element;
+            var lineNumber = lineInfo.HasLineInfo() ? lineInfo.LineNumber : 0;
+
+            // Skip if not in diff scope
+            if (lineNumber > 0 && !context.IsLineInScope(lineNumber))
+                continue;
+
+            // Check if suppressed
+            if (IsSuppressed(suppressions, RuleId, lineNumber))
+                continue;
+
+            var packageName = element.Attribute("Include")?.Value ??
+                              element.Attribute("Update")?.Value ??
+                              "Unknown";
+            var version = versionAttr?.Value ?? versionElement?.Value ?? "Unknown";
+
+            // Skip if version is empty
+            if (string.IsNullOrWhiteSpace(version))
+                continue;
+
+            yield return new DetectionResult(
+                RuleId,
+                Name,
+                DetectionSeverity.Warning,
+                context.FilePath,
+                lineNumber,
+                lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
+                $"Version attribute on PackageReference bypasses Central Package Management for '{packageName}' (version: {version})",
+                element.ToString(),
+                "Remove Version attribute and add package to Directory.Packages.props, or add suppression comment with justification"
+            );
+        }
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Clears the CPM detection cache. Useful for testing.
+    /// </summary>
+    internal static void ClearCache()
+    {
+        CpmCache.Clear();
+    }
+}

--- a/src/Slopwatch/Slopwatch.csproj
+++ b/src/Slopwatch/Slopwatch.csproj
@@ -9,7 +9,13 @@
     <!-- NuGet package configuration -->
     <IsPackable>true</IsPackable>
     <PackageId>Slopwatch</PackageId>
+
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Expose internals to test project -->
+    <InternalsVisibleTo Include="Slopwatch.Tests" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Akka.Streams" />

--- a/tests/Slopwatch.Tests/Detection/PackageVersionOverrideRuleTests.cs
+++ b/tests/Slopwatch.Tests/Detection/PackageVersionOverrideRuleTests.cs
@@ -1,0 +1,552 @@
+using Slopwatch.Detection;
+using Slopwatch.Detection.Rules;
+using Xunit;
+
+namespace Slopwatch.Tests.Detection;
+
+/// <summary>
+/// Tests for SW006 - Package Version Override Detection Rule
+/// </summary>
+public class PackageVersionOverrideRuleTests : IDisposable
+{
+    private readonly PackageVersionOverrideRule _rule = new();
+
+    public PackageVersionOverrideRuleTests()
+    {
+        // Clear cache before each test
+        PackageVersionOverrideRule.ClearCache();
+    }
+
+    public void Dispose()
+    {
+        // Clean up cache after tests
+        PackageVersionOverrideRule.ClearCache();
+    }
+
+    #region VersionOverride Tests (Always Slop)
+
+    [Fact]
+    public void Test_DetectsVersionOverrideAttribute()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+        Assert.Contains("VersionOverride", result.Message);
+        Assert.Contains("Newtonsoft.Json", result.Message);
+        Assert.Contains("13.0.1", result.Message);
+        Assert.Equal(DetectionSeverity.Warning, result.Severity);
+        Assert.Equal(3, result.LineNumber);
+    }
+
+    [Fact]
+    public void Test_DetectsVersionOverrideWithUpdateAttribute()
+    {
+        // Arrange - Using Update instead of Include
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Update=""xunit"" VersionOverride=""2.6.0"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+        Assert.Contains("xunit", result.Message);
+    }
+
+    [Fact]
+    public void Test_DetectsVersionOverrideInPropsFile()
+    {
+        // Arrange
+        const string xml = @"<Project>
+  <ItemGroup>
+    <PackageReference Include=""SomePackage"" VersionOverride=""1.0.0"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Directory.Build.props");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+    }
+
+    [Fact]
+    public void Test_DetectsVersionOverrideInTargetsFile()
+    {
+        // Arrange
+        const string xml = @"<Project>
+  <ItemGroup>
+    <PackageReference Include=""SomePackage"" VersionOverride=""1.0.0"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Custom.targets");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+    }
+
+    [Fact]
+    public void Test_DetectsMultipleVersionOverrides()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""PackageA"" VersionOverride=""1.0.0"" />
+    <PackageReference Include=""PackageB"" VersionOverride=""2.0.0"" />
+    <PackageReference Include=""PackageC"" VersionOverride=""3.0.0"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        Assert.Equal(3, results.Count);
+        Assert.All(results, r => Assert.Equal("SW006", r.RuleId));
+        Assert.Contains(results, r => r.Message.Contains("PackageA"));
+        Assert.Contains(results, r => r.Message.Contains("PackageB"));
+        Assert.Contains(results, r => r.Message.Contains("PackageC"));
+    }
+
+    [Fact]
+    public void Test_DetectsVersionOverrideEvenInDirectoryPackagesProps()
+    {
+        // VersionOverride shouldn't be in Directory.Packages.props but if it is, flag it
+        const string xml = @"<Project>
+  <ItemGroup>
+    <PackageReference Include=""SomePackage"" VersionOverride=""1.0.0"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Directory.Packages.props");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - VersionOverride is always flagged
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+        Assert.Contains("VersionOverride", result.Message);
+    }
+
+    #endregion
+
+    #region Version Attribute Tests (Context-Aware)
+
+    [Fact]
+    public void Test_DetectsVersionAttributeWhenCpmEnabled()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" Version=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+        _rule.CpmEnabledOverride = true; // Simulate CPM enabled
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+        Assert.Contains("Version attribute", result.Message);
+        Assert.Contains("Newtonsoft.Json", result.Message);
+    }
+
+    [Fact]
+    public void Test_IgnoresVersionAttributeWhenNoCpm()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" Version=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+        _rule.CpmEnabledOverride = false; // Simulate CPM disabled
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_NeverFlagsVersionInDirectoryPackagesProps()
+    {
+        // Arrange - This is the correct place for versions
+        const string xml = @"<Project>
+  <ItemGroup>
+    <PackageVersion Include=""Newtonsoft.Json"" Version=""13.0.1"" />
+    <PackageVersion Include=""xunit"" Version=""2.6.0"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Directory.Packages.props");
+        _rule.CpmEnabledOverride = true;
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - PackageVersion elements are fine, and Version shouldn't be flagged here
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_DetectsNestedVersionElement()
+    {
+        // Arrange - Version as child element instead of attribute
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"">
+      <Version>13.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+        _rule.CpmEnabledOverride = true;
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+        Assert.Contains("Version attribute", result.Message);
+        Assert.Contains("13.0.1", result.Message);
+    }
+
+    [Fact]
+    public void Test_IgnoresEmptyVersionAttribute()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" Version="""" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+        _rule.CpmEnabledOverride = true;
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - Empty version is ignored
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_IgnoresPackageReferenceWithoutVersion()
+    {
+        // Arrange - Clean CPM usage
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" />
+    <PackageReference Include=""xunit"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+        _rule.CpmEnabledOverride = true;
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - No violations for proper CPM usage
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_DoesNotDoubleReportVersionOverrideWithVersion()
+    {
+        // Arrange - Has both Version and VersionOverride
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" Version=""13.0.0"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+        _rule.CpmEnabledOverride = true;
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - Only VersionOverride is reported, not both
+        var result = Assert.Single(results);
+        Assert.Contains("VersionOverride", result.Message);
+    }
+
+    #endregion
+
+    #region Suppression Tests
+
+    [Fact]
+    public void Test_IgnoresSuppressedVersionOverride()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <!-- slopwatch-ignore: SW006 This package requires a specific version due to API compatibility requirements -->
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_IgnoresSuppressedVersionAttribute()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <!-- slopwatch-ignore: SW006 This test project needs an isolated version for testing purposes -->
+    <PackageReference Include=""Newtonsoft.Json"" Version=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+        _rule.CpmEnabledOverride = true;
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_RequiresSufficientJustificationLength()
+    {
+        // Arrange - Short justification (less than 20 chars)
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <!-- slopwatch-ignore: SW006 short -->
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - Should still detect because justification is too short
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+    }
+
+    [Fact]
+    public void Test_CaseInsensitiveSuppression()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <!-- SLOPWATCH-IGNORE: sw006 This package requires a specific version due to API compatibility requirements -->
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void Test_HandlesInvalidXmlGracefully()
+    {
+        // Arrange - Malformed XML
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1""
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - Should not throw, should return empty results
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_HandlesEmptyFile()
+    {
+        // Arrange
+        const string xml = "";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Test_RespectsLineScope()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""PackageA"" VersionOverride=""1.0.0"" />
+    <PackageReference Include=""PackageB"" VersionOverride=""2.0.0"" />
+  </ItemGroup>
+</Project>";
+        // Only line 3 is in scope
+        var context = CreateContextWithLineScope(xml, "Test.csproj", addedLines: new[] { 3 });
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - Only line 3 (PackageA) should be detected
+        var result = Assert.Single(results);
+        Assert.Equal(3, result.LineNumber);
+        Assert.Contains("PackageA", result.Message);
+    }
+
+    [Fact]
+    public void Test_ProvidesCodeSnippet()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.NotNull(result.CodeSnippet);
+        Assert.Contains("<PackageReference", result.CodeSnippet);
+        Assert.Contains("VersionOverride", result.CodeSnippet);
+    }
+
+    [Fact]
+    public void Test_ProvidesSuggestedFix()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.NotNull(result.SuggestedFix);
+        Assert.Contains("Directory.Packages.props", result.SuggestedFix);
+    }
+
+    [Fact]
+    public void Test_HandlesConditionalItemGroups()
+    {
+        // Arrange
+        const string xml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup Condition=""'$(TargetFramework)' == 'net8.0'"">
+    <PackageReference Include=""Newtonsoft.Json"" VersionOverride=""13.0.1"" />
+  </ItemGroup>
+</Project>";
+        var context = CreateContext(xml, "Test.csproj");
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - Should still detect in conditional ItemGroups
+        var result = Assert.Single(results);
+        Assert.Equal("SW006", result.RuleId);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private DetectionContext CreateContext(string xml, string fileName)
+    {
+        return new DetectionContext(
+            FilePath: $"/src/{fileName}",
+            FileName: fileName,
+            Content: xml,
+            SyntaxTree: null, // No Roslyn syntax tree for XML files
+            IsTestFile: false
+        );
+    }
+
+    private DetectionContext CreateContextWithLineScope(string xml, string fileName, int[]? addedLines = null, int[]? modifiedLines = null)
+    {
+        return new DetectionContext(
+            FilePath: $"/src/{fileName}",
+            FileName: fileName,
+            Content: xml,
+            SyntaxTree: null,
+            IsTestFile: false,
+            AddedLines: addedLines != null ? new HashSet<int>(addedLines) : null,
+            ModifiedLines: modifiedLines != null ? new HashSet<int>(modifiedLines) : null
+        );
+    }
+
+    private List<DetectionResult> RunRule(DetectionContext context)
+    {
+        var results = new List<DetectionResult>();
+        var enumerable = _rule.AnalyzeAsync(context);
+
+        var enumerator = enumerable.GetAsyncEnumerator();
+        try
+        {
+            while (enumerator.MoveNextAsync().AsTask().Result)
+            {
+                results.Add(enumerator.Current);
+            }
+        }
+        finally
+        {
+            enumerator.DisposeAsync().AsTask().Wait();
+        }
+
+        return results;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Adds new detection rule SW006 for Central Package Management (CPM) version override abuse
- Detects `VersionOverride` attribute (always flagged - explicit CPM bypass)
- Detects `Version` attribute when CPM is enabled (context-aware detection)
- CPM detection walks directory tree looking for `Directory.Packages.props` or `ManagePackageVersionsCentrally` setting

## Test plan
- [x] 28 unit tests added covering all detection scenarios
- [x] All 170 tests pass
- [x] `slopwatch list-rules` shows SW006
- [x] Documentation updated in README.md and CLAUDE.md