### PR TITLE
Add MultiEdit to Claude Code hook matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Add slopwatch as a hook to catch slop patterns during AI-assisted coding. Add th
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Adds `MultiEdit` to the hook matcher pattern in the README's Claude Code integration example

The hook configuration was missing the `MultiEdit` tool, which meant code changes made via MultiEdit would bypass slopwatch analysis entirely.

## Test plan
- [x] Verify the matcher pattern is correct: `Write|Edit|MultiEdit`