### PR TITLE
Downgrade to .NET 8 for broader compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <Copyright>Copyright © 2025-$([System.DateTime]::Now.Year) Aaron Stannard</Copyright>
     <Authors>Aaron Stannard</Authors>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -23,8 +22,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->
-    <NetCoreVersion>net9.0</NetCoreVersion>
-    <NetCoreTestVersion>net9.0</NetCoreTestVersion>
+    <NetCoreVersion>net8.0</NetCoreVersion>
+    <NetCoreTestVersion>net8.0</NetCoreTestVersion>
   </PropertyGroup>
   <!-- GitHub SourceLink -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <!-- Nuget package versions -->
     <RoslynVersion>4.13.0</RoslynVersion>
     <CommandLineParserVersion>2.9.1</CommandLineParserVersion>
-    <FileSystemGlobbingVersion>9.0.0</FileSystemGlobbingVersion>
+    <FileSystemGlobbingVersion>8.0.0</FileSystemGlobbingVersion>
     <XunitVersion>2.9.3</XunitVersion>
     <XunitRunnerVersion>3.0.2</XunitRunnerVersion>
     <TestSdkVersion>17.12.0</TestSdkVersion>


### PR DESCRIPTION
close #31

## Summary
- Downgrades target framework from .NET 9 to .NET 8 for broader compatibility
- Downgrades `Microsoft.Extensions.FileSystemGlobbing` from 9.0.0 to 8.0.0
- Removes unused `NoWarn` for CS1591 (documentation generation is not enabled)

## Rationale
No .NET 9-specific APIs or C# 13-specific language features were being used. .NET 8 is LTS and more widely deployed.

## Test plan
- [x] `dotnet build` succeeds
- [x] All 170 tests pass