### PR TITLE
Improve hook error messages for AI assistant clarity

### DIFF
--- a/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
@@ -398,21 +398,28 @@ public sealed class AnalyzeCommand
             return 0;
         }
 
-        // Output to stderr in a format Claude can understand
-        await Console.Error.WriteLineAsync("SLOPWATCH BLOCKED: Your edit introduced code that violates slopwatch rules.");
+        // Output to stderr in a format AI assistants and humans can understand
+        await Console.Error.WriteLineAsync("SLOPWATCH BLOCKED: Code changes violate slopwatch rules.");
         await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync("=== VIOLATIONS ===");
 
         foreach (var issue in issues)
         {
             await Console.Error.WriteLineAsync($"- {issue.FilePath}:{issue.LineNumber} [{issue.RuleId}]: {issue.Message}");
             if (!string.IsNullOrEmpty(issue.SuggestedFix))
             {
-                await Console.Error.WriteLineAsync($"  Fix: {issue.SuggestedFix}");
+                await Console.Error.WriteLineAsync($"  Remediation: {issue.SuggestedFix}");
             }
         }
 
         await Console.Error.WriteLineAsync();
-        await Console.Error.WriteLineAsync("Fix these issues properly instead of working around them.");
+        await Console.Error.WriteLineAsync("=== REQUIRED ACTION ===");
+        await Console.Error.WriteLineAsync("You MUST fix these violations before proceeding. Do NOT:");
+        await Console.Error.WriteLineAsync("  - Ignore this warning and continue with other tasks");
+        await Console.Error.WriteLineAsync("  - Add more suppressions to hide the problem");
+        await Console.Error.WriteLineAsync("  - Disable tests, warnings, or error checking");
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync("Instead, address the root cause of each violation.");
 
         return 2;
     }

--- a/src/Slopwatch/Detection/Rules/DisabledTestRule.cs
+++ b/src/Slopwatch/Detection/Rules/DisabledTestRule.cs
@@ -101,7 +101,7 @@ public sealed class DisabledTestRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     $"Test method '{method.Identifier.Text}' is disabled with #if false directive",
                     GetMethodSnippet(method),
-                    "Remove #if false directive or add suppression (attribute, inline comment, or config file)"
+                    "Remove the #if false directive and fix the test so it passes. If the test must be disabled, use [SlopwatchSuppress(\"SW001\", \"reason with 20+ chars\")]"
                 );
                 continue;
             }
@@ -134,7 +134,7 @@ public sealed class DisabledTestRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     message,
                     disabledAttribute.ToString(),
-                    "Remove Skip/Ignore attribute or add suppression (attribute, inline comment, or config file)"
+                    "Remove the Skip/Ignore attribute and fix the test so it passes. If the test must be disabled, use [SlopwatchSuppress(\"SW001\", \"reason with 20+ chars\")]"
                 );
             }
         }

--- a/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
+++ b/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
@@ -98,7 +98,7 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     "Empty catch block swallows exceptions without handling",
                     GetCatchSnippet(catchClause),
-                    "Handle the exception, rethrow it, or add suppression (attribute, inline comment, or config file)"
+                    "Add proper exception handling (log and rethrow, or handle the error condition). If the empty catch is intentional, use [SlopwatchSuppress(\"SW003\", \"reason with 20+ chars\")]"
                 );
                 continue;
             }
@@ -115,7 +115,7 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     "Catch block only logs exception without rethrowing or handling",
                     GetCatchSnippet(catchClause),
-                    "Consider rethrowing the exception or handling it appropriately"
+                    "Add 'throw;' after logging to rethrow, or add actual error handling. If logging-only is intentional, use [SlopwatchSuppress(\"SW003\", \"reason with 20+ chars\")]"
                 );
             }
         }

--- a/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
+++ b/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
@@ -273,7 +273,7 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
                 lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
                 $"VersionOverride explicitly bypasses Central Package Management for '{packageName}' (version: {version})",
                 element.ToString(),
-                "Remove VersionOverride and use the centrally managed version in Directory.Packages.props, or add suppression comment with justification"
+                $"Remove VersionOverride='{version}' and update the version in Directory.Packages.props instead. If override is required, add: <!-- slopwatch-ignore: SW006 [your justification here] -->"
             );
         }
 
@@ -339,7 +339,7 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
                 lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
                 $"Version attribute on PackageReference bypasses Central Package Management for '{packageName}' (version: {version})",
                 element.ToString(),
-                "Remove Version attribute and add package to Directory.Packages.props, or add suppression comment with justification"
+                $"Remove Version='{version}' from PackageReference and add '<PackageVersion Include=\"{packageName}\" Version=\"{version}\" />' to Directory.Packages.props. If inline version is required, add: <!-- slopwatch-ignore: SW006 [your justification here] -->"
             );
         }
 

--- a/src/Slopwatch/Detection/Rules/ProjectFileRule.cs
+++ b/src/Slopwatch/Detection/Rules/ProjectFileRule.cs
@@ -186,7 +186,7 @@ public sealed class ProjectFileRule : IDetectionRule
                         lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
                         $"Adding warnings to NoWarn: {warnings}",
                         element.ToString(),
-                        "Fix the underlying issues or add suppression comment with justification"
+                        $"Remove the NoWarn entry and fix the underlying code issues causing {warnings}. If suppression is truly necessary, add: <!-- slopwatch-ignore: SW005 [your justification here] -->"
                     );
                 }
             }
@@ -202,7 +202,7 @@ public sealed class ProjectFileRule : IDetectionRule
                     lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
                     $"Setting NoWarn to suppress warnings: {value}",
                     element.ToString(),
-                    "Fix the underlying issues or add suppression comment with justification"
+                    $"Remove the NoWarn entry and fix the underlying code issues causing {value}. If suppression is truly necessary, add: <!-- slopwatch-ignore: SW005 [your justification here] -->"
                 );
             }
         }
@@ -252,7 +252,7 @@ public sealed class ProjectFileRule : IDetectionRule
                     lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
                     "TreatWarningsAsErrors is disabled - warnings will not fail the build",
                     element.ToString(),
-                    "Enable TreatWarningsAsErrors or add suppression comment with justification"
+                    "Set TreatWarningsAsErrors to true and fix all warnings in the code. If you must disable it, add: <!-- slopwatch-ignore: SW005 [your justification here] -->"
                 );
             }
         }
@@ -302,7 +302,7 @@ public sealed class ProjectFileRule : IDetectionRule
                     lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
                     "Nullable reference types are disabled",
                     element.ToString(),
-                    "Consider enabling nullable reference types or add suppression comment with justification"
+                    "Set Nullable to 'enable' and fix nullability warnings. If disabling is intentional, add: <!-- slopwatch-ignore: SW005 [your justification here] -->"
                 );
             }
         }
@@ -352,7 +352,7 @@ public sealed class ProjectFileRule : IDetectionRule
                     lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
                     "WarningsAsErrors is empty - no warnings will be treated as errors",
                     element.ToString(),
-                    "Specify warnings to treat as errors or add suppression comment with justification"
+                    "Remove the empty WarningsAsErrors element or specify which warnings should be errors. If intentional, add: <!-- slopwatch-ignore: SW005 [your justification here] -->"
                 );
             }
         }

--- a/src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs
+++ b/src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs
@@ -98,7 +98,7 @@ public sealed class TimeoutJigglingRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     $"Test uses Task.Delay({delayValue}) which may indicate a timing-dependent test",
                     invocation.ToString(),
-                    "Use proper synchronization (e.g., TaskCompletionSource, ManualResetEvent) or add suppression (attribute, inline comment, or config file)"
+                    "Replace Task.Delay with proper synchronization (TaskCompletionSource, SemaphoreSlim, or test framework's async helpers). If delay is intentional (testing timeouts), use [SlopwatchSuppress(\"SW004\", \"reason with 20+ chars\")]"
                 );
             }
             // Check for Thread.Sleep
@@ -114,7 +114,7 @@ public sealed class TimeoutJigglingRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     $"Test uses Thread.Sleep({delayValue}) which may indicate a timing-dependent test",
                     invocation.ToString(),
-                    "Use proper synchronization (e.g., TaskCompletionSource, ManualResetEvent) or add suppression (attribute, inline comment, or config file)"
+                    "Replace Thread.Sleep with async Task.Delay or proper synchronization primitives. If delay is intentional (testing timeouts), use [SlopwatchSuppress(\"SW004\", \"reason with 20+ chars\")]"
                 );
             }
             // Check for SpinWait
@@ -129,7 +129,7 @@ public sealed class TimeoutJigglingRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     "Test uses SpinWait which may indicate a timing-dependent test",
                     invocation.ToString(),
-                    "Use proper synchronization instead of busy-waiting or add suppression (attribute, inline comment, or config file)"
+                    "Replace SpinWait with proper synchronization primitives (ManualResetEventSlim, SemaphoreSlim). If SpinWait is intentional, use [SlopwatchSuppress(\"SW004\", \"reason with 20+ chars\")]"
                 );
             }
         }
@@ -164,7 +164,7 @@ public sealed class TimeoutJigglingRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     "Test creates SpinWait instance which may indicate a timing-dependent test",
                     creation.ToString(),
-                    "Use proper synchronization instead of busy-waiting or add suppression (attribute, inline comment, or config file)"
+                    "Replace SpinWait with proper synchronization primitives (ManualResetEventSlim, SemaphoreSlim). If SpinWait is intentional, use [SlopwatchSuppress(\"SW004\", \"reason with 20+ chars\")]"
                 );
             }
         }

--- a/src/Slopwatch/Detection/Rules/WarningSuppressRule.cs
+++ b/src/Slopwatch/Detection/Rules/WarningSuppressRule.cs
@@ -150,7 +150,7 @@ public sealed class WarningSuppressRule : IDetectionRule
                 location.StartLinePosition.Character + 1,
                 $"#pragma warning disable for {warningText} without matching restore in same scope",
                 directive.ToString(),
-                "Add #pragma warning restore or add suppression (attribute, inline comment, or config file)"
+                $"Fix the code causing {warningText} and remove the #pragma, or add matching #pragma warning restore. If suppression is needed, use [SlopwatchSuppress(\"SW002\", \"reason with 20+ chars\")]"
             );
         }
 
@@ -209,7 +209,7 @@ public sealed class WarningSuppressRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     $"SuppressMessage attribute suppressing {suppressionInfo}",
                     attribute.ToString(),
-                    "Remove attribute or add suppression (attribute, inline comment, or config file)"
+                    $"Fix the code causing {suppressionInfo} and remove the SuppressMessage attribute. If suppression is needed, use [SlopwatchSuppress(\"SW002\", \"reason with 20+ chars\")]"
                 );
             }
         }

--- a/tests/Slopwatch.Tests/Detection/DisabledTestRuleTests.cs
+++ b/tests/Slopwatch.Tests/Detection/DisabledTestRuleTests.cs
@@ -352,7 +352,7 @@ public class TestClass
         var result = Assert.Single(results);
         Assert.NotNull(result.SuggestedFix);
         Assert.Contains("Remove", result.SuggestedFix);
-        Assert.Contains("suppression", result.SuggestedFix);
+        Assert.Contains("SlopwatchSuppress", result.SuggestedFix);
     }
 
     [Fact]

--- a/tests/Slopwatch.Tests/Detection/EmptyCatchBlockRuleTests.cs
+++ b/tests/Slopwatch.Tests/Detection/EmptyCatchBlockRuleTests.cs
@@ -393,7 +393,7 @@ public class TestClass
         // Assert
         var result = Assert.Single(results);
         Assert.NotNull(result.SuggestedFix);
-        Assert.Contains("Handle", result.SuggestedFix);
+        Assert.Contains("exception handling", result.SuggestedFix);
     }
 
     [Fact]

--- a/tests/Slopwatch.Tests/Detection/ProjectFileRuleTests.cs
+++ b/tests/Slopwatch.Tests/Detection/ProjectFileRuleTests.cs
@@ -411,7 +411,7 @@ public class ProjectFileRuleTests
         // Assert
         var result = Assert.Single(results);
         Assert.NotNull(result.SuggestedFix);
-        Assert.Contains("Enable", result.SuggestedFix);
+        Assert.Contains("TreatWarningsAsErrors", result.SuggestedFix);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #33

## Summary
- Improved hook output with structured sections (VIOLATIONS, REQUIRED ACTION)
- Added explicit "Do NOT" guidance to prevent common workarounds
- Enhanced suggested fixes across all rules to be more specific and actionable

## Changes

### Hook Output (AnalyzeCommand.cs)
New output format:
```
SLOPWATCH BLOCKED: Code changes violate slopwatch rules.

=== VIOLATIONS ===
- /path/file.cs:5 [SW005]: Adding warnings to NoWarn: CS1591
  Remediation: Remove the NoWarn entry and fix the underlying code issues...

=== REQUIRED ACTION ===
You MUST fix these violations before proceeding. Do NOT:
  - Ignore this warning and continue with other tasks
  - Add more suppressions to hide the problem
  - Disable tests, warnings, or error checking

Instead, address the root cause of each violation.
```

### Improved Suggested Fixes
- **SW001**: Now shows exact `[SlopwatchSuppress("SW001", "reason with 20+ chars")]` syntax
- **SW002**: Includes the specific warning codes being suppressed
- **SW003**: Recommends "log and rethrow" pattern explicitly
- **SW004**: Suggests specific synchronization primitives (TaskCompletionSource, SemaphoreSlim, etc.)
- **SW005**: Shows exact `<!-- slopwatch-ignore: SW005 [...] -->` comment syntax
- **SW006**: Shows exact `<PackageVersion Include="..." Version="..." />` element to add

## Test plan
- [x] `dotnet build` succeeds
- [x] All 170 tests pass
- [x] Updated 3 tests that asserted on old suggested fix text