### PR TITLE
Fix --version and --help returning exit code 2

### DIFF
--- a/src/Slopwatch.Cmd/Program.cs
+++ b/src/Slopwatch.Cmd/Program.cs
@@ -29,7 +29,7 @@ public static class Program
                     (AnalyzeCommand cmd) => cmd.ExecuteAsync(cts.Token),
                     (InitCommand cmd) => cmd.ExecuteAsync(cts.Token),
                     (ListRulesCommand cmd) => cmd.ExecuteAsync(cts.Token),
-                    errors => Task.FromResult(2));
+                    errors => Task.FromResult(HandleParseErrors(errors)));
         }
         catch (OperationCanceledException)
         {
@@ -41,5 +41,23 @@ public static class Program
             await Console.Error.WriteLineAsync($"Unhandled error: {ex.Message}");
             return 2;
         }
+    }
+
+    /// <summary>
+    /// Handles parse errors and returns the appropriate exit code.
+    /// </summary>
+    /// <param name="errors">The parse errors from CommandLineParser.</param>
+    /// <returns>0 for --version and --help requests, 2 for actual errors.</returns>
+    private static int HandleParseErrors(IEnumerable<Error> errors)
+    {
+        var errorList = errors.ToList();
+
+        // --version and --help are not errors, they should return 0
+        if (errorList.All(e => e is VersionRequestedError or HelpVerbRequestedError or HelpRequestedError))
+        {
+            return 0;
+        }
+
+        return 2;
     }
 }


### PR DESCRIPTION
## Summary

- Fixed `--version` and `--help` commands returning exit code 2 instead of 0
- Added `HandleParseErrors` method to distinguish between actual parse errors and valid help/version requests
- The CommandLineParser library treats `--version` and `--help` as "errors" in the parsing result, but they are actually successful operations

## Changes

- Added check for `VersionRequestedError`, `HelpVerbRequestedError`, and `HelpRequestedError` types
- These now return exit code 0 while actual parse errors continue to return exit code 2

## Test plan

- [x] `dotnet run --project src/Slopwatch.Cmd -- --version` returns exit code 0
- [x] `dotnet run --project src/Slopwatch.Cmd -- --help` returns exit code 0
- [x] Invalid options like `--invalid-option` still return exit code 2
- [x] All existing tests pass

Fixes #43