### PR TITLE
SW003: Exclude catch blocks that log exceptions

### DIFF
--- a/docs/slop-patterns.md
+++ b/docs/slop-patterns.md
@@ -135,7 +135,7 @@ namespace MyApp { ... }
 **Detection Methods**:
 - Roslyn pattern: `CatchClauseSyntax` with empty or whitespace-only block
 - Allow exceptions: Empty catch blocks with comments explaining intentional suppression
-- Refinement: Flag catches with only basic logging but no handling or recovery
+- Logging IS handling: Catch blocks containing logging calls (Log., Logger., Console.Write, etc.) are NOT flagged - logging is considered valid handling for fire-and-forget operations, background jobs, and graceful degradation scenarios
 
 **Example Violation**:
 ```csharp
@@ -165,21 +165,21 @@ public void SaveData(string data)
 try { ... }
 catch (Exception ex)
 {
-    // TODO: handle this
+    // TODO: handle this (no actual handling)
 }
 
 // Catch with only comment
 try { ... }
 catch (Exception ex)
 {
-    // This should never happen
+    // This should never happen (but no logging either)
 }
 
-// Catch-all with no logging
+// Catch-all with no logging or handling
 try { ... }
 catch (Exception)
 {
-    return null;
+    return null; // Silently returns null without logging
 }
 
 // Multiple empty catches
@@ -187,6 +187,11 @@ try { ... }
 catch (IOException) { }
 catch (TimeoutException) { }
 ```
+
+**Note**: Catch blocks with logging calls (Console.WriteLine, Logger.Error, etc.) are NOT flagged because logging IS handling for many legitimate scenarios:
+- Fire-and-forget operations (email sending, telemetry)
+- Background jobs where failures shouldn't crash the application
+- Graceful degradation where one subsystem's failure shouldn't affect others
 
 ---
 

--- a/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
+++ b/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
@@ -15,8 +15,10 @@ namespace Slopwatch.Detection.Rules;
 /// <list type="bullet">
 /// <item><description>Are completely empty</description></item>
 /// <item><description>Only contain comments</description></item>
-/// <item><description>Only log without rethrowing or handling</description></item>
 /// </list>
+///
+/// Note: Catch blocks that log exceptions are NOT flagged. Logging IS handling
+/// for fire-and-forget operations, background jobs, and graceful degradation scenarios.
 ///
 /// Empty catch blocks often indicate:
 /// <list type="bullet">
@@ -98,24 +100,7 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
                     location.StartLinePosition.Character + 1,
                     "Empty catch block swallows exceptions without handling",
                     GetCatchSnippet(catchClause),
-                    "Add proper exception handling (log and rethrow, or handle the error condition). If the empty catch is intentional, use [SlopwatchSuppress(\"SW003\", \"reason with 20+ chars\")]"
-                );
-                continue;
-            }
-
-            // Check if catch block only logs without rethrowing
-            if (IsLoggingOnlyWithoutRethrow(catchClause))
-            {
-                yield return new DetectionResult(
-                    RuleId,
-                    Name,
-                    DetectionSeverity.Warning, // Lower severity for logging-only
-                    context.FilePath,
-                    lineNumber,
-                    location.StartLinePosition.Character + 1,
-                    "Catch block only logs exception without rethrowing or handling",
-                    GetCatchSnippet(catchClause),
-                    "Add 'throw;' after logging to rethrow, or add actual error handling. If logging-only is intentional, use [SlopwatchSuppress(\"SW003\", \"reason with 20+ chars\")]"
+                    "Add proper exception handling (log the error, or handle the error condition). If the empty catch is intentional, use [SlopwatchSuppress(\"SW003\", \"reason with 20+ chars\")]"
                 );
             }
         }
@@ -142,48 +127,6 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Checks if a catch block only logs without rethrowing
-    /// </summary>
-    private static bool IsLoggingOnlyWithoutRethrow(CatchClauseSyntax catchClause)
-    {
-        if (catchClause.Block is null || catchClause.Block.Statements.Count == 0)
-            return false;
-
-        var statements = catchClause.Block.Statements;
-        var hasLogging = false;
-        var hasRethrow = false;
-        var hasOtherStatements = false;
-
-        foreach (var statement in statements)
-        {
-            var statementText = statement.ToString().ToLowerInvariant();
-
-            // Check for throw or throw ex
-            if (statement is ThrowStatementSyntax)
-            {
-                hasRethrow = true;
-            }
-            // Check for logging patterns
-            else if (statementText.Contains("log.") ||
-                     statementText.Contains("logger.") ||
-                     statementText.Contains("console.write") ||
-                     statementText.Contains("debug.write") ||
-                     statementText.Contains("trace.write"))
-            {
-                hasLogging = true;
-            }
-            // Any other statement means there's actual handling
-            else if (!string.IsNullOrWhiteSpace(statement.ToString().Trim()))
-            {
-                hasOtherStatements = true;
-            }
-        }
-
-        // Only flag if it's logging only without rethrow or other handling
-        return hasLogging && !hasRethrow && !hasOtherStatements;
     }
 
     /// <summary>

--- a/tests/Slopwatch.Tests.Fixtures/EmptyCatchSamples.cs
+++ b/tests/Slopwatch.Tests.Fixtures/EmptyCatchSamples.cs
@@ -41,9 +41,9 @@ public class EmptyCatchSamples
         }
     }
 
-    // SHOULD TRIGGER: SW003 (Warning severity)
-    // Catch block that only logs without rethrowing
-    public void CatchWithOnlyLogging_ShouldTrigger()
+    // SHOULD NOT TRIGGER (logging IS handling)
+    // Catch block that logs is legitimate - fire-and-forget, background jobs, graceful degradation
+    public void CatchWithOnlyLogging_ShouldNotTrigger()
     {
         try
         {
@@ -53,13 +53,13 @@ public class EmptyCatchSamples
         catch (Exception ex)
         {
             Console.WriteLine($"Error occurred: {ex.Message}");
-            // Logs but doesn't rethrow or handle
+            // Logging IS handling - this is valid for fire-and-forget scenarios
         }
     }
 
-    // SHOULD TRIGGER: SW003 (Warning severity)
-    // Using logger but not rethrowing
-    public void CatchWithLogger_NoRethrow_ShouldTrigger()
+    // SHOULD NOT TRIGGER (logging IS handling)
+    // Using logger is valid handling - logs the failure for debugging
+    public void CatchWithLogger_NoRethrow_ShouldNotTrigger()
     {
         var logger = CreateLogger();
         try
@@ -70,7 +70,7 @@ public class EmptyCatchSamples
         catch (HttpRequestException ex)
         {
             logger.LogError($"API call failed: {ex}");
-            // Should rethrow or return error, not just log
+            // Logging is valid handling for non-critical operations
         }
     }
 
@@ -121,9 +121,9 @@ public class EmptyCatchSamples
         }
     }
 
-    // SHOULD TRIGGER: SW003 (Warning severity)
-    // Multiple catch blocks, one with only logging
-    public void MultipleCatchBlocks_OneWithOnlyLogging_ShouldTrigger()
+    // SHOULD NOT TRIGGER (logging IS handling)
+    // Multiple catch blocks, logging is valid handling
+    public void MultipleCatchBlocks_OneWithOnlyLogging_ShouldNotTrigger()
     {
         try
         {
@@ -136,7 +136,7 @@ public class EmptyCatchSamples
         }
         catch (Exception ex)
         {
-            // This one only logs
+            // Logging IS handling - valid for graceful degradation
             Console.WriteLine($"Unexpected error: {ex}");
         }
     }

--- a/tests/Slopwatch.Tests/Detection/EmptyCatchBlockRuleTests.cs
+++ b/tests/Slopwatch.Tests/Detection/EmptyCatchBlockRuleTests.cs
@@ -79,9 +79,10 @@ public class TestClass
     }
 
     [Fact]
-    public void Test_DetectsLoggingOnlyCatch()
+    public void Test_IgnoresLoggingOnlyCatch()
     {
-        // Arrange
+        // Arrange - catch blocks with logging are NOT flagged
+        // Logging IS handling for fire-and-forget operations, background jobs, etc.
         const string code = @"
 public class TestClass
 {
@@ -104,18 +105,15 @@ public class TestClass
         // Act
         var results = RunRule(context);
 
-        // Assert
-        var result = Assert.Single(results);
-        Assert.Equal("SW003", result.RuleId);
-        Assert.Contains("only logs", result.Message);
-        Assert.Contains("without rethrowing", result.Message);
-        Assert.Equal(DetectionSeverity.Warning, result.Severity);
+        // Assert - logging is considered valid handling, not flagged
+        Assert.Empty(results);
     }
 
     [Fact]
-    public void Test_DetectsConsoleWriteOnlyCatch()
+    public void Test_IgnoresConsoleWriteOnlyCatch()
     {
-        // Arrange
+        // Arrange - catch blocks with console output are NOT flagged
+        // Logging to console IS handling for debugging and simple scenarios
         const string code = @"
 public class TestClass
 {
@@ -138,11 +136,8 @@ public class TestClass
         // Act
         var results = RunRule(context);
 
-        // Assert
-        var result = Assert.Single(results);
-        Assert.Equal("SW003", result.RuleId);
-        Assert.Contains("only logs", result.Message);
-        Assert.Equal(DetectionSeverity.Warning, result.Severity);
+        // Assert - console output is considered valid handling, not flagged
+        Assert.Empty(results);
     }
 
     [Fact]
@@ -341,9 +336,40 @@ public class TestClass
     }
 
     [Fact]
-    public void Test_DetectsMultipleCatchBlocks()
+    public void Test_DetectsMultipleEmptyCatchBlocks()
     {
         // Arrange
+        const string code = @"
+public class TestClass
+{
+    public void Method1()
+    {
+        try { DoSomething(); }
+        catch (Exception) { }
+    }
+
+    public void Method2()
+    {
+        try { DoSomething(); }
+        catch (Exception) { }
+    }
+
+    private void DoSomething() { }
+}";
+        var context = CreateContext(code);
+
+        // Act
+        var results = RunRule(context);
+
+        // Assert - only empty catches are flagged, logging is allowed
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal("SW003", r.RuleId));
+    }
+
+    [Fact]
+    public void Test_OnlyFlagsEmptyCatchNotLogging()
+    {
+        // Arrange - one empty catch and one logging catch
         const string code = @"
 public class TestClass
 {
@@ -366,9 +392,10 @@ public class TestClass
         // Act
         var results = RunRule(context);
 
-        // Assert
-        Assert.Equal(2, results.Count);
-        Assert.All(results, r => Assert.Equal("SW003", r.RuleId));
+        // Assert - only the empty catch is flagged, logging is allowed
+        var result = Assert.Single(results);
+        Assert.Equal("SW003", result.RuleId);
+        Assert.Equal(7, result.LineNumber);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Catch blocks containing logging calls are no longer flagged as SW003 violations
- Logging IS handling for many legitimate scenarios including fire-and-forget operations, background jobs, and graceful degradation

## Changes

- Removed `IsLoggingOnlyWithoutRethrow` check from `EmptyCatchBlockRule`
- Updated rule documentation to clarify that logging is valid handling
- Updated unit tests to reflect new behavior
- Updated test fixtures with corrected expectations
- Updated `slop-patterns.md` documentation

## Rationale

Per issue #42, flagging catch blocks with logging was overly aggressive:

> Logging IS handling in many contexts, especially for:
> 1. **Fire-and-forget operations** (email sending, telemetry, notifications)
> 2. **Background jobs** where you want to log errors but continue processing
> 3. **Graceful degradation** patterns where a failure in one subsystem shouldn't affect the main flow

The intent of SW003 is to catch truly empty catch blocks or blocks that swallow exceptions **silently**. A catch block with logging is explicitly NOT silent - it's recording the failure for debugging.

## Test plan

- [x] `Test_IgnoresLoggingOnlyCatch` - logging-only catch is not flagged
- [x] `Test_IgnoresConsoleWriteOnlyCatch` - Console.WriteLine catch is not flagged
- [x] `Test_OnlyFlagsEmptyCatchNotLogging` - empty catch is flagged, logging catch is not
- [x] All 171 tests pass

Fixes #42