### PR TITLE
SW006: Treat version overrides as errors

### DIFF
--- a/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
+++ b/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
@@ -40,7 +40,7 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
         "when Central Package Management is enabled in the repository.";
 
     /// <inheritdoc />
-    public DetectionSeverity DefaultSeverity => DetectionSeverity.Warning;
+    public DetectionSeverity DefaultSeverity => DetectionSeverity.Error;
 
     /// <inheritdoc />
     public IReadOnlyList<string> ApplicableFilePatterns => new[] { "*.csproj", "*.props", "*.targets" };
@@ -267,7 +267,7 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
             yield return new DetectionResult(
                 RuleId,
                 Name,
-                DetectionSeverity.Warning,
+                DetectionSeverity.Error,
                 context.FilePath,
                 lineNumber,
                 lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,
@@ -333,7 +333,7 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
             yield return new DetectionResult(
                 RuleId,
                 Name,
-                DetectionSeverity.Warning,
+                DetectionSeverity.Error,
                 context.FilePath,
                 lineNumber,
                 lineInfo.HasLineInfo() ? lineInfo.LinePosition : 1,

--- a/tests/Slopwatch.Tests/Detection/PackageVersionOverrideRuleTests.cs
+++ b/tests/Slopwatch.Tests/Detection/PackageVersionOverrideRuleTests.cs
@@ -45,7 +45,7 @@ public class PackageVersionOverrideRuleTests : IDisposable
         Assert.Contains("VersionOverride", result.Message);
         Assert.Contains("Newtonsoft.Json", result.Message);
         Assert.Contains("13.0.1", result.Message);
-        Assert.Equal(DetectionSeverity.Warning, result.Severity);
+        Assert.Equal(DetectionSeverity.Error, result.Severity);
         Assert.Equal(3, result.LineNumber);
     }
 


### PR DESCRIPTION
## Summary
- raise SW006 default severity and detection results to error level
- align SW006 unit test expectations with error severity

## Testing
- not run (not requested)