### PR TITLE
Release 0.3.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,15 +5,9 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.2</VersionPrefix>
     <PackageReleaseNotes>**Compatibility:**
-* Downgraded to .NET 8 for broader compatibility across environments (PR #34)
-
-**Bug Fixes:**
-* MultiEdit tool now properly analyzed in Claude Code hook mode (PR #32)
-
-**Documentation:**
-* Improved hook error messages for clarity when working with programming assistants (PR #35)</PackageReleaseNotes>
+* SW006 now treats CPM package version overrides (`Version` and `VersionOverride`) as errors, preventing inline overrides when CPM is enabled (PR #48)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 0.3.2 January 17th 2026 ####
+
+**Compatibility:**
+* SW006 now treats CPM package version overrides (`Version` and `VersionOverride`) as errors, preventing inline overrides when CPM is enabled (PR #48)
+
 #### 0.3.1 January 14th 2026 ####
 
 **Bug Fixes:**


### PR DESCRIPTION
## Summary
- Publish release notes and version metadata for 0.3.2.
- SW006 now treats CPM package version overrides as errors, preventing inline overrides when CPM is enabled.

## Testing
- Not run (release metadata update only).