### PR TITLE
Fix init command to scan .props and .targets files

### DIFF
--- a/src/Slopwatch.Cmd/Commands/InitCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/InitCommand.cs
@@ -16,7 +16,7 @@ public sealed class InitCommand
     [Option('d', "directory", HelpText = "Directory to initialize (default: current directory)")]
     public string? Directory { get; set; }
 
-    [Option('p', "patterns", HelpText = "Glob patterns to match (default: **/*.cs, **/*.csproj)", Separator = ',')]
+    [Option('p', "patterns", HelpText = "Glob patterns to match (default: **/*.cs, **/*.csproj, **/*.props, **/*.targets)", Separator = ',')]
     public IEnumerable<string>? Patterns { get; set; }
 
     [Option("exclude", HelpText = "Patterns to exclude", Separator = ',')]
@@ -92,7 +92,7 @@ public sealed class InitCommand
 
             // Analyze directory
             // CommandLineParser initializes IEnumerable to empty (not null), so check Any()
-            var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj" };
+            var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj", "**/*.props", "**/*.targets" };
 
             await Console.Out.WriteLineAsync("Scanning for existing issues...");
 


### PR DESCRIPTION
## Summary
- Fixes file pattern mismatch between `init` and `analyze` commands
- `init` now scans `**/*.props` and `**/*.targets` files in addition to `.cs` and `.csproj`
- Updated help text to reflect the new default patterns

## Root Cause
The `init` command was only scanning `**/*.cs` and `**/*.csproj` files, while `analyze` scans `**/*.cs`, `**/*.csproj`, `**/*.props`, and `**/*.targets`. This caused baselines to be incomplete when projects had SW005 violations in `Directory.Build.props` or similar MSBuild files.

Fixes #52

## Test plan
- [ ] Run `slopwatch init` on a project with `Directory.Build.props` containing `<NoWarn>CS1591</NoWarn>`
- [ ] Verify the SW005 violation is detected and baselined
- [ ] Run `slopwatch analyze` and verify no new issues (since it was baselined)