### PR TITLE
Use relaxed JSON escaping for more readable output

### DIFF
--- a/src/Slopwatch.Cmd/Output/JsonOutputFormatter.cs
+++ b/src/Slopwatch.Cmd/Output/JsonOutputFormatter.cs
@@ -1,3 +1,4 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Slopwatch.Detection;
 
@@ -11,7 +12,8 @@ public sealed class JsonOutputFormatter : IOutputFormatter
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
     /// <inheritdoc />

--- a/src/Slopwatch/Baseline/BaselineFile.cs
+++ b/src/Slopwatch/Baseline/BaselineFile.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Slopwatch.Detection;
@@ -19,7 +20,8 @@ public sealed class BaselineFile
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Adds `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` to JSON serialization options
- Affects both baseline.json output and `--format json` output

## Problem
The baseline.json contained unicode escapes like `\u0027` instead of `'` and `\u003C`/`\u003E` instead of `<`/`>`. While valid JSON, this made the files less human-readable.

Fixes #50

## Files Modified
- `src/Slopwatch/Baseline/BaselineFile.cs`
- `src/Slopwatch.Cmd/Output/JsonOutputFormatter.cs`

## Backwards Compatibility
No breaking changes - System.Text.Json reads both escaped (`\u0027`) and unescaped (`'`) formats correctly. Existing baselines will continue to work.

## Test plan
- [ ] Run `slopwatch init` on a project with violations
- [ ] Check baseline.json - apostrophes should appear as `'` not `\u0027`
- [ ] Run `slopwatch analyze --format json` - verify same unescaped output
- [ ] Verify existing baselines with old escaping still load correctly