### PR TITLE
Centralize default file patterns to prevent drift

### DIFF
--- a/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs
@@ -20,7 +20,7 @@ public sealed class AnalyzeCommand
     [Option('d', "directory", HelpText = "Directory to analyze (default: current directory)")]
     public string? Directory { get; set; }
 
-    [Option('p', "patterns", HelpText = "Glob patterns to match (default: **/*.cs, **/*.csproj)", Separator = ',')]
+    [Option('p', "patterns", HelpText = DefaultPatterns.HelpText, Separator = ',')]
     public IEnumerable<string>? Patterns { get; set; }
 
     [Option('o', "output", HelpText = "Output format: console, json (default: console)")]
@@ -221,7 +221,7 @@ public sealed class AnalyzeCommand
                 }
 
                 // CommandLineParser initializes IEnumerable to empty (not null), so check Any()
-                var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj", "**/*.props", "**/*.targets" };
+                var patterns = Patterns?.Any() == true ? Patterns.ToArray() : DefaultPatterns.FilePatterns;
 
                 // Get the list of files to analyze
                 var fileList = analyzer.GetMatchingFiles(rootDirectory, patterns).ToList();

--- a/src/Slopwatch.Cmd/Commands/DefaultPatterns.cs
+++ b/src/Slopwatch.Cmd/Commands/DefaultPatterns.cs
@@ -1,0 +1,24 @@
+namespace Slopwatch.Cmd.Commands;
+
+/// <summary>
+/// Default file patterns used by slopwatch commands.
+/// </summary>
+internal static class DefaultPatterns
+{
+    /// <summary>
+    /// Default glob patterns for scanning .NET projects.
+    /// Includes C# source files and MSBuild project/props/targets files.
+    /// </summary>
+    public static readonly string[] FilePatterns =
+    {
+        "**/*.cs",
+        "**/*.csproj",
+        "**/*.props",
+        "**/*.targets"
+    };
+
+    /// <summary>
+    /// Human-readable description of the default patterns for help text.
+    /// </summary>
+    public const string HelpText = "Glob patterns to match (default: **/*.cs, **/*.csproj, **/*.props, **/*.targets)";
+}

--- a/src/Slopwatch.Cmd/Commands/InitCommand.cs
+++ b/src/Slopwatch.Cmd/Commands/InitCommand.cs
@@ -16,7 +16,7 @@ public sealed class InitCommand
     [Option('d', "directory", HelpText = "Directory to initialize (default: current directory)")]
     public string? Directory { get; set; }
 
-    [Option('p', "patterns", HelpText = "Glob patterns to match (default: **/*.cs, **/*.csproj, **/*.props, **/*.targets)", Separator = ',')]
+    [Option('p', "patterns", HelpText = DefaultPatterns.HelpText, Separator = ',')]
     public IEnumerable<string>? Patterns { get; set; }
 
     [Option("exclude", HelpText = "Patterns to exclude", Separator = ',')]
@@ -92,7 +92,7 @@ public sealed class InitCommand
 
             // Analyze directory
             // CommandLineParser initializes IEnumerable to empty (not null), so check Any()
-            var patterns = Patterns?.Any() == true ? Patterns.ToArray() : new[] { "**/*.cs", "**/*.csproj", "**/*.props", "**/*.targets" };
+            var patterns = Patterns?.Any() == true ? Patterns.ToArray() : DefaultPatterns.FilePatterns;
 
             await Console.Out.WriteLineAsync("Scanning for existing issues...");
 


### PR DESCRIPTION
## Summary
- Introduces `DefaultPatterns` class with shared `FilePatterns` array and `HelpText` constant
- Both `init` and `analyze` commands now reference the same defaults
- Prevents future drift like the one fixed in #52

## Files Changed
- **Created**: `src/Slopwatch.Cmd/Commands/DefaultPatterns.cs`
- **Modified**: `src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs` - uses `DefaultPatterns.FilePatterns` and `DefaultPatterns.HelpText`
- **Modified**: `src/Slopwatch.Cmd/Commands/InitCommand.cs` - uses `DefaultPatterns.FilePatterns` and `DefaultPatterns.HelpText`

## Test plan
- [x] Build succeeds
- [x] All 171 tests pass