### PR TITLE
Prepare release notes for v0.3.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 0.3.4 February 18th 2026 ####
+
+**New Features:**
+* `.razor` files (Blazor) are now scanned by default - SW001-SW006 detection rules apply to Razor components without requiring explicit `-f` flags (PR #64)
+
 #### 0.3.3 January 20th 2026 ####
 
 **Bug Fixes:**


### PR DESCRIPTION
## Summary

- Adds 0.3.4 entry to `RELEASE_NOTES.md` covering `.razor` file support (PR #64)

## Release notes entry

```
#### 0.3.4 February 18th 2026 ####

**New Features:**
* `.razor` files (Blazor) are now scanned by default - SW001-SW006 detection rules apply to Razor components without requiring explicit `-f` flags (PR #64)
```