### PR TITLE
Prepare release notes for v0.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,13 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.2</VersionPrefix>
-    <PackageReleaseNotes>**Compatibility:**
-* SW006 now treats CPM package version overrides (`Version` and `VersionOverride`) as errors, preventing inline overrides when CPM is enabled (PR #48)</PackageReleaseNotes>
+    <VersionPrefix>0.4.0</VersionPrefix>
+    <PackageReleaseNotes>**Bug Fixes:**
+* `--config` flag now properly loads custom suppression configurations during analysis - the option was previously documented but not wired into the analysis pipeline (PR #71)
+* Hook mode now falls back to full file analysis when `git status` is unavailable (e.g., outside a git repository), instead of silently returning no results (PR #71)
+
+**Documentation:**
+* Updated README examples to reflect correct `.slopwatch/config.json` schema, SW006 severity levels, and local tool installation instructions (PR #71)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+#### 0.4.0 March 2nd 2026 ####
+
+**Bug Fixes:**
+* `--config` flag now properly loads custom suppression configurations during analysis - the option was previously documented but not wired into the analysis pipeline (PR #71)
+* Hook mode now falls back to full file analysis when `git status` is unavailable (e.g., outside a git repository), instead of silently returning no results (PR #71)
+
+**Documentation:**
+* Updated README examples to reflect correct `.slopwatch/config.json` schema, SW006 severity levels, and local tool installation instructions (PR #71)
+
 #### 0.3.4 February 18th 2026 ####
 
 **New Features:**


### PR DESCRIPTION
## Summary

- Updates `RELEASE_NOTES.md` with the 0.4.0 release entry (March 2nd 2026)
- Bumps `VersionPrefix` in `Directory.Build.props` to `0.4.0`
- Updates `PackageReleaseNotes` in `Directory.Build.props` with the 0.4.0 changelog

## Changes included in this release

**Bug Fixes:**
- `--config` flag now properly loads custom suppression configurations during analysis - the option was previously documented but not wired into the analysis pipeline (PR #71)
- Hook mode now falls back to full file analysis when `git status` is unavailable (e.g., outside a git repository), instead of silently returning no results (PR #71)

**Documentation:**
- Updated README examples to reflect correct `.slopwatch/config.json` schema, SW006 severity levels, and local tool installation instructions (PR #71)

## Test plan

- [x] `dotnet build` passes with 0 warnings and 0 errors
- [x] `VersionPrefix` in `Directory.Build.props` updated to `0.4.0`
- [x] `RELEASE_NOTES.md` entry formatted consistently with prior releases