### PR TITLE
Fix project file suppressions

### DIFF
--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
   "createdAt": "2026-01-11T16:03:39.2213093+00:00",
-  "updatedAt": "2026-01-11T16:03:39.2283389+00:00",
-  "description": "Initial baseline created by \u0027slopwatch init\u0027 on 2026-01-11 16:03:39 UTC",
+  "updatedAt": "2026-04-13T20:06:27.3536741+00:00",
+  "description": "Initial baseline created by 'slopwatch init' on 2026-01-11 16:03:39 UTC",
   "entries": [
     {
       "hash": "44fac096fcddc658",
       "ruleId": "SW005",
       "filePath": "tests/Slopwatch.Tests.Fixtures/Slopwatch.Tests.Fixtures.csproj",
       "lineNumber": 15,
-      "codeSnippet": "\u003CNoWarn\u003E$(NoWarn);xUnit1013;xUnit1030;xUnit1031\u003C/NoWarn\u003E",
+      "codeSnippet": "<NoWarn>$(NoWarn);xUnit1013;xUnit1030;xUnit1031</NoWarn>",
       "message": "Adding warnings to NoWarn: xUnit1013;xUnit1030;xUnit1031",
       "baselinedAt": "2026-01-11T16:03:39.2281131+00:00"
     },
@@ -18,7 +18,7 @@
       "ruleId": "SW005",
       "filePath": "tests/Slopwatch.Tests.Fixtures/Slopwatch.Tests.Fixtures.csproj",
       "lineNumber": 17,
-      "codeSnippet": "\u003CNoWarn\u003E$(NoWarn);CS0169;CS8618\u003C/NoWarn\u003E",
+      "codeSnippet": "<NoWarn>$(NoWarn);CS0169;CS8618</NoWarn>",
       "message": "Adding warnings to NoWarn: CS0169;CS8618",
       "baselinedAt": "2026-01-11T16:03:39.2282534+00:00"
     },
@@ -27,7 +27,7 @@
       "ruleId": "SW005",
       "filePath": "tests/Slopwatch.Tests.Fixtures/Slopwatch.Tests.Fixtures.csproj",
       "lineNumber": 13,
-      "codeSnippet": "\u003CTreatWarningsAsErrors\u003Efalse\u003C/TreatWarningsAsErrors\u003E",
+      "codeSnippet": "<TreatWarningsAsErrors>false</TreatWarningsAsErrors>",
       "message": "TreatWarningsAsErrors is disabled - warnings will not fail the build",
       "baselinedAt": "2026-01-11T16:03:39.228261+00:00"
     },
@@ -45,7 +45,7 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch/Detection/Rules/WarningSuppressRule.cs",
       "lineNumber": 291,
-      "codeSnippet": "catch\n            {\n                // If we can\u0027t access the directory, continue up\n            }",
+      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
       "message": "Empty catch block swallows exceptions without handling",
       "baselinedAt": "2026-01-11T16:03:39.2282846+00:00"
     },
@@ -54,7 +54,7 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs",
       "lineNumber": 268,
-      "codeSnippet": "catch\n            {\n                // If we can\u0027t access the directory, continue up\n            }",
+      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
       "message": "Empty catch block swallows exceptions without handling",
       "baselinedAt": "2026-01-11T16:03:39.2282935+00:00"
     },
@@ -63,7 +63,7 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch/Detection/Rules/DisabledTestRule.cs",
       "lineNumber": 290,
-      "codeSnippet": "catch\n            {\n                // If we can\u0027t access the directory, continue up\n            }",
+      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
       "message": "Empty catch block swallows exceptions without handling",
       "baselinedAt": "2026-01-11T16:03:39.2282987+00:00"
     },
@@ -72,7 +72,7 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs",
       "lineNumber": 278,
-      "codeSnippet": "catch\n            {\n                // If we can\u0027t access the directory, continue up\n            }",
+      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
       "message": "Empty catch block swallows exceptions without handling",
       "baselinedAt": "2026-01-11T16:03:39.2283035+00:00"
     },
@@ -99,7 +99,7 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch.Cmd/Program.cs",
       "lineNumber": 39,
-      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\u0022Unhandled error: {ex.Message}\u0022);\n            return 2;\n        }",
+      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\"Unhandled error: {ex.Message}\");\n            return 2;\n        }",
       "message": "Catch block uses overly broad exception type: Exception",
       "baselinedAt": "2026-01-11T16:03:39.2283215+00:00"
     },
@@ -108,7 +108,7 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs",
       "lineNumber": 221,
-      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\u0022Error during analysis: {ex.Message}\u0022);\n            if (ex.InnerException is not null)\n            {\n    // ...",
+      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\"Error during analysis: {ex.Message}\");\n            if (ex.InnerException is not null)\n            {\n    // ...",
       "message": "Catch block uses overly broad exception type: Exception",
       "baselinedAt": "2026-01-11T16:03:39.2283274+00:00"
     },
@@ -117,7 +117,7 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch.Cmd/Commands/ListRulesCommand.cs",
       "lineNumber": 54,
-      "codeSnippet": "catch (Exception ex)\n        {\n            Console.Error.WriteLine($\u0022Error listing rules: {ex.Message}\u0022);\n            return Task.FromResult(2);\n        }",
+      "codeSnippet": "catch (Exception ex)\n        {\n            Console.Error.WriteLine($\"Error listing rules: {ex.Message}\");\n            return Task.FromResult(2);\n        }",
       "message": "Catch block uses overly broad exception type: Exception",
       "baselinedAt": "2026-01-11T16:03:39.2283335+00:00"
     },
@@ -126,9 +126,18 @@
       "ruleId": "SW003",
       "filePath": "src/Slopwatch.Cmd/Commands/InitCommand.cs",
       "lineNumber": 149,
-      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\u0022Error during initialization: {ex.Message}\u0022);\n            return 2;\n        }",
+      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\"Error during initialization: {ex.Message}\");\n            return 2;\n        }",
       "message": "Catch block uses overly broad exception type: Exception",
       "baselinedAt": "2026-01-11T16:03:39.2283388+00:00"
+    },
+    {
+      "hash": "e45be01c2f7ebb97",
+      "ruleId": "SW003",
+      "filePath": "src/Slopwatch/Analysis/ProjectRootLocator.cs",
+      "lineNumber": 38,
+      "codeSnippet": "catch\r\n            {\r\n                // If we can't access the directory, continue up.\r\n            }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-13T20:06:27.353673+00:00"
     }
   ]
 }

--- a/src/Slopwatch/Analysis/ProjectRootLocator.cs
+++ b/src/Slopwatch/Analysis/ProjectRootLocator.cs
@@ -1,0 +1,55 @@
+namespace Slopwatch.Analysis;
+
+/// <summary>
+/// Resolves the effective project root for analysis features that need repository-level files.
+/// Prefers repository markers and falls back to the nearest solution directory.
+/// </summary>
+internal static class ProjectRootLocator
+{
+    public static string FindRoot(string filePath)
+    {
+        var directory = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrEmpty(directory))
+        {
+            return Directory.GetCurrentDirectory();
+        }
+
+        string? nearestSolutionDirectory = null;
+
+        while (directory != null)
+        {
+            try
+            {
+                // Look for common project root indicators
+                if (Directory.Exists(Path.Combine(directory, ".git")) ||
+                    Directory.Exists(Path.Combine(directory, ".slopwatch")))
+                {
+                    return directory;
+                }
+
+                // Look for nearest solution directory
+                if (nearestSolutionDirectory is null &&
+                    (Directory.GetFiles(directory, "*.slnx").Length > 0 ||
+                     Directory.GetFiles(directory, "*.sln").Length > 0))
+                {
+                    nearestSolutionDirectory = directory;
+                }
+            }
+            catch
+            {
+                // If we can't access the directory, continue up.
+            }
+
+            var parent = Path.GetDirectoryName(directory);
+            if (parent == directory)
+            {
+                break;
+            }
+
+            directory = parent;
+        }
+
+        // Fallback to the nearest solution directory, file's directory or current directory
+        return nearestSolutionDirectory ?? Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
+    }
+}

--- a/src/Slopwatch/Detection/Rules/DisabledTestRule.cs
+++ b/src/Slopwatch/Detection/Rules/DisabledTestRule.cs
@@ -282,7 +282,8 @@ public sealed class DisabledTestRule : IDetectionRule
                 // Look for common project root indicators
                 if (Directory.Exists(Path.Combine(directory, ".git")) ||
                     Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any())
+                    Directory.GetFiles(directory, "*.sln").Any() ||
+                    Directory.GetFiles(directory, "*.slnx").Any())
                 {
                     return directory;
                 }

--- a/src/Slopwatch/Detection/Rules/DisabledTestRule.cs
+++ b/src/Slopwatch/Detection/Rules/DisabledTestRule.cs
@@ -64,8 +64,7 @@ public sealed class DisabledTestRule : IDetectionRule
             .GetSemanticModel(context.SyntaxTree);
 
         // Create suppression checker
-        var projectRoot = GetProjectRoot(context.FilePath);
-        var suppressionChecker = await SuppressionChecker.CreateAsync(context, projectRoot, cancellationToken);
+        var suppressionChecker = await SuppressionChecker.CreateAsync(context, cancellationToken);
 
         // Find all method declarations
         var methods = root.DescendantNodes()
@@ -262,45 +261,6 @@ public sealed class DisabledTestRule : IDetectionRule
         }
 
         return activeIf;
-    }
-
-    /// <summary>
-    /// Gets the project root directory from a file path.
-    /// </summary>
-    private static string GetProjectRoot(string filePath)
-    {
-        var directory = Path.GetDirectoryName(filePath);
-        if (string.IsNullOrEmpty(directory))
-        {
-            return Directory.GetCurrentDirectory();
-        }
-
-        while (directory != null)
-        {
-            try
-            {
-                // Look for common project root indicators
-                if (Directory.Exists(Path.Combine(directory, ".git")) ||
-                    Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any() ||
-                    Directory.GetFiles(directory, "*.slnx").Any())
-                {
-                    return directory;
-                }
-            }
-            catch
-            {
-                // If we can't access the directory, continue up
-            }
-
-            var parent = Path.GetDirectoryName(directory);
-            if (parent == directory) // Reached root
-                break;
-            directory = parent;
-        }
-
-        // Fallback to the file's directory or current directory
-        return Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
     }
 
     /// <summary>

--- a/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
+++ b/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
@@ -65,8 +65,7 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
         var root = await context.SyntaxTree.GetRootAsync(cancellationToken);
 
         // Create suppression checker
-        var projectRoot = GetProjectRoot(context.FilePath);
-        var suppressionChecker = await SuppressionChecker.CreateAsync(context, projectRoot, cancellationToken);
+        var suppressionChecker = await SuppressionChecker.CreateAsync(context, cancellationToken);
 
         // Find all catch clauses
         var catchClauses = root.DescendantNodes()
@@ -141,45 +140,6 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
             node = node.Parent;
         }
         return null;
-    }
-
-    /// <summary>
-    /// Gets the project root directory from a file path.
-    /// </summary>
-    private static string GetProjectRoot(string filePath)
-    {
-        var directory = Path.GetDirectoryName(filePath);
-        if (string.IsNullOrEmpty(directory))
-        {
-            return Directory.GetCurrentDirectory();
-        }
-
-        while (directory != null)
-        {
-            try
-            {
-                // Look for common project root indicators
-                if (Directory.Exists(Path.Combine(directory, ".git")) ||
-                    Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any() ||
-                    Directory.GetFiles(directory, "*.slnx").Any())
-                {
-                    return directory;
-                }
-            }
-            catch
-            {
-                // If we can't access the directory, continue up
-            }
-
-            var parent = Path.GetDirectoryName(directory);
-            if (parent == directory) // Reached root
-                break;
-            directory = parent;
-        }
-
-        // Fallback to the file's directory or current directory
-        return Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
     }
 
     /// <summary>

--- a/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
+++ b/src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs
@@ -161,7 +161,8 @@ public sealed class EmptyCatchBlockRule : IDetectionRule
                 // Look for common project root indicators
                 if (Directory.Exists(Path.Combine(directory, ".git")) ||
                     Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any())
+                    Directory.GetFiles(directory, "*.sln").Any() ||
+                    Directory.GetFiles(directory, "*.slnx").Any())
                 {
                     return directory;
                 }

--- a/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
+++ b/src/Slopwatch/Detection/Rules/PackageVersionOverrideRule.cs
@@ -136,9 +136,10 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
     }
 
     /// <summary>
-    /// Checks if a specific line is suppressed.
+    /// Checks whether the specified rule is suppressed by an XML slopwatch-ignore comment
+    /// on the line immediately preceding the reported XML element.
     /// </summary>
-    private static bool IsSuppressed(List<(string RuleId, string Justification, int Line)> suppressions, string ruleId, int lineNumber)
+    private static bool IsSuppressedByXmlComment(List<(string RuleId, string Justification, int Line)> suppressions, string ruleId, int lineNumber)
     {
         // Check if there's a suppression comment on the line immediately before
         return suppressions.Any(s =>
@@ -256,7 +257,7 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (IsSuppressed(suppressions, RuleId, lineNumber))
+            if (IsSuppressedByXmlComment(suppressions, RuleId, lineNumber))
                 continue;
 
             var packageName = element.Attribute("Include")?.Value ??
@@ -318,7 +319,7 @@ public sealed class PackageVersionOverrideRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (IsSuppressed(suppressions, RuleId, lineNumber))
+            if (IsSuppressedByXmlComment(suppressions, RuleId, lineNumber))
                 continue;
 
             var packageName = element.Attribute("Include")?.Value ??

--- a/src/Slopwatch/Detection/Rules/ProjectFileRule.cs
+++ b/src/Slopwatch/Detection/Rules/ProjectFileRule.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
+using Slopwatch.Suppression;
 
 namespace Slopwatch.Detection.Rules;
 
@@ -74,26 +75,29 @@ public sealed class ProjectFileRule : IDetectionRule
             yield break;
         }
 
+        var projectRoot = GetProjectRoot(context.FilePath);
+        var suppressionChecker = await SuppressionChecker.CreateAsync(context, projectRoot, cancellationToken);
+
         // Check for NoWarn additions
-        await foreach (var result in AnalyzeNoWarn(context, document, suppressions, cancellationToken))
+        await foreach (var result in AnalyzeNoWarn(context, document, suppressions, suppressionChecker, cancellationToken))
         {
             yield return result;
         }
 
         // Check for TreatWarningsAsErrors disabled
-        await foreach (var result in AnalyzeTreatWarningsAsErrors(context, document, suppressions, cancellationToken))
+        await foreach (var result in AnalyzeTreatWarningsAsErrors(context, document, suppressions, suppressionChecker, cancellationToken))
         {
             yield return result;
         }
 
         // Check for Nullable disabled
-        await foreach (var result in AnalyzeNullable(context, document, suppressions, cancellationToken))
+        await foreach (var result in AnalyzeNullable(context, document, suppressions, suppressionChecker, cancellationToken))
         {
             yield return result;
         }
 
         // Check for WarningsAsErrors removal (empty or missing)
-        await foreach (var result in AnalyzeWarningsAsErrors(context, document, suppressions, cancellationToken))
+        await foreach (var result in AnalyzeWarningsAsErrors(context, document, suppressions, suppressionChecker, cancellationToken))
         {
             yield return result;
         }
@@ -130,7 +134,7 @@ public sealed class ProjectFileRule : IDetectionRule
     /// <summary>
     /// Checks if a specific line is suppressed.
     /// </summary>
-    private static bool IsSuppressed(List<(string RuleId, string Justification, int Line)> suppressions, string ruleId, int lineNumber)
+    private static bool IsXmlSuppressed(List<(string RuleId, string Justification, int Line)> suppressions, string ruleId, int lineNumber)
     {
         // Check if there's a suppression comment on the line immediately before
         return suppressions.Any(s =>
@@ -145,6 +149,7 @@ public sealed class ProjectFileRule : IDetectionRule
         DetectionContext context,
         XDocument document,
         List<(string RuleId, string Justification, int Line)> suppressions,
+        SuppressionChecker suppressionChecker,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var noWarnElements = document.Descendants()
@@ -163,7 +168,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (IsSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -217,6 +222,7 @@ public sealed class ProjectFileRule : IDetectionRule
         DetectionContext context,
         XDocument document,
         List<(string RuleId, string Justification, int Line)> suppressions,
+        SuppressionChecker suppressionChecker,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var elements = document.Descendants()
@@ -235,7 +241,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (IsSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -267,6 +273,7 @@ public sealed class ProjectFileRule : IDetectionRule
         DetectionContext context,
         XDocument document,
         List<(string RuleId, string Justification, int Line)> suppressions,
+        SuppressionChecker suppressionChecker,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var elements = document.Descendants()
@@ -285,7 +292,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (IsSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -317,6 +324,7 @@ public sealed class ProjectFileRule : IDetectionRule
         DetectionContext context,
         XDocument document,
         List<(string RuleId, string Justification, int Line)> suppressions,
+        SuppressionChecker suppressionChecker,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var elements = document.Descendants()
@@ -335,7 +343,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (IsSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -358,5 +366,35 @@ public sealed class ProjectFileRule : IDetectionRule
         }
 
         await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Gets the project root directory from a file path.
+    /// </summary>
+    private static string GetProjectRoot(string filePath)
+    {
+        var directory = Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
+        while (!string.IsNullOrEmpty(directory))
+        {
+            try
+            {
+                if (Directory.Exists(Path.Combine(directory, ".git")) ||
+                    Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
+                    Directory.GetFiles(directory, "*.sln").Any() ||
+                    Directory.GetFiles(directory, "*.slnx").Any())
+                {
+                    return directory;
+                }
+            }
+            catch
+            {
+            }
+
+            var parent = Path.GetDirectoryName(directory);
+            if (parent == directory)
+                break;
+            directory = parent;
+        }
+        return Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
     }
 }

--- a/src/Slopwatch/Detection/Rules/ProjectFileRule.cs
+++ b/src/Slopwatch/Detection/Rules/ProjectFileRule.cs
@@ -75,8 +75,7 @@ public sealed class ProjectFileRule : IDetectionRule
             yield break;
         }
 
-        var projectRoot = GetProjectRoot(context.FilePath);
-        var suppressionChecker = await SuppressionChecker.CreateAsync(context, projectRoot, cancellationToken);
+        var suppressionChecker = await SuppressionChecker.CreateAsync(context, cancellationToken);
 
         // Check for NoWarn additions
         await foreach (var result in AnalyzeNoWarn(context, document, suppressions, suppressionChecker, cancellationToken))
@@ -132,9 +131,10 @@ public sealed class ProjectFileRule : IDetectionRule
     }
 
     /// <summary>
-    /// Checks if a specific line is suppressed.
+    /// Checks whether the specified rule is suppressed by an XML slopwatch-ignore comment
+    /// on the line immediately preceding the reported XML element.
     /// </summary>
-    private static bool IsXmlSuppressed(List<(string RuleId, string Justification, int Line)> suppressions, string ruleId, int lineNumber)
+    private static bool IsSuppressedByXmlComment(List<(string RuleId, string Justification, int Line)> suppressions, string ruleId, int lineNumber)
     {
         // Check if there's a suppression comment on the line immediately before
         return suppressions.Any(s =>
@@ -168,7 +168,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsSuppressedByXmlComment(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -241,7 +241,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsSuppressedByXmlComment(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -292,7 +292,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsSuppressedByXmlComment(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -343,7 +343,7 @@ public sealed class ProjectFileRule : IDetectionRule
                 continue;
 
             // Check if suppressed
-            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsXmlSuppressed(suppressions, RuleId, lineNumber))
+            if (suppressionChecker.IsSuppressed(context, null, RuleId, lineNumber) || IsSuppressedByXmlComment(suppressions, RuleId, lineNumber))
                 continue;
 
             var value = element.Value.Trim();
@@ -368,33 +368,4 @@ public sealed class ProjectFileRule : IDetectionRule
         await Task.CompletedTask;
     }
 
-    /// <summary>
-    /// Gets the project root directory from a file path.
-    /// </summary>
-    private static string GetProjectRoot(string filePath)
-    {
-        var directory = Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
-        while (!string.IsNullOrEmpty(directory))
-        {
-            try
-            {
-                if (Directory.Exists(Path.Combine(directory, ".git")) ||
-                    Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any() ||
-                    Directory.GetFiles(directory, "*.slnx").Any())
-                {
-                    return directory;
-                }
-            }
-            catch
-            {
-            }
-
-            var parent = Path.GetDirectoryName(directory);
-            if (parent == directory)
-                break;
-            directory = parent;
-        }
-        return Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
-    }
 }

--- a/src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs
+++ b/src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs
@@ -270,7 +270,8 @@ public sealed class TimeoutJigglingRule : IDetectionRule
                 // Look for common project root indicators
                 if (Directory.Exists(Path.Combine(directory, ".git")) ||
                     Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any())
+                    Directory.GetFiles(directory, "*.sln").Any() ||
+                    Directory.GetFiles(directory, "*.slnx").Any())
                 {
                     return directory;
                 }

--- a/src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs
+++ b/src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs
@@ -62,8 +62,7 @@ public sealed class TimeoutJigglingRule : IDetectionRule
         var root = await context.SyntaxTree.GetRootAsync(cancellationToken);
 
         // Create suppression checker
-        var projectRoot = GetProjectRoot(context.FilePath);
-        var suppressionChecker = await SuppressionChecker.CreateAsync(context, projectRoot, cancellationToken);
+        var suppressionChecker = await SuppressionChecker.CreateAsync(context, cancellationToken);
 
         // Find all invocation expressions (method calls)
         var invocations = root.DescendantNodes()
@@ -252,42 +251,4 @@ public sealed class TimeoutJigglingRule : IDetectionRule
         return null;
     }
 
-    /// <summary>
-    /// Gets the project root directory from a file path.
-    /// </summary>
-    private static string GetProjectRoot(string filePath)
-    {
-        var directory = Path.GetDirectoryName(filePath);
-        if (string.IsNullOrEmpty(directory))
-        {
-            return Directory.GetCurrentDirectory();
-        }
-
-        while (directory != null)
-        {
-            try
-            {
-                // Look for common project root indicators
-                if (Directory.Exists(Path.Combine(directory, ".git")) ||
-                    Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any() ||
-                    Directory.GetFiles(directory, "*.slnx").Any())
-                {
-                    return directory;
-                }
-            }
-            catch
-            {
-                // If we can't access the directory, continue up
-            }
-
-            var parent = Path.GetDirectoryName(directory);
-            if (parent == directory) // Reached root
-                break;
-            directory = parent;
-        }
-
-        // Fallback to the file's directory or current directory
-        return Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
-    }
 }

--- a/src/Slopwatch/Detection/Rules/WarningSuppressRule.cs
+++ b/src/Slopwatch/Detection/Rules/WarningSuppressRule.cs
@@ -58,8 +58,7 @@ public sealed class WarningSuppressRule : IDetectionRule
         var root = await context.SyntaxTree.GetRootAsync(cancellationToken);
 
         // Create suppression checker
-        var projectRoot = GetProjectRoot(context.FilePath);
-        var suppressionChecker = await SuppressionChecker.CreateAsync(context, projectRoot, cancellationToken);
+        var suppressionChecker = await SuppressionChecker.CreateAsync(context, cancellationToken);
 
         // Check for #pragma warning disable directives
         await foreach (var result in AnalyzePragmaDirectives(context, root, suppressionChecker, cancellationToken))
@@ -117,7 +116,7 @@ public sealed class WarningSuppressRule : IDetectionRule
                         .OrderByDescending(kvp => kvp.Key)
                         .ToList();
 
-                    if (matchedDisables.Any())
+                    if (matchedDisables.Count > 0)
                     {
                         // Remove the matched disable
                         disableDirectives.Remove(matchedDisables.First().Key);
@@ -265,42 +264,4 @@ public sealed class WarningSuppressRule : IDetectionRule
         return null;
     }
 
-    /// <summary>
-    /// Gets the project root directory from a file path.
-    /// </summary>
-    private static string GetProjectRoot(string filePath)
-    {
-        var directory = Path.GetDirectoryName(filePath);
-        if (string.IsNullOrEmpty(directory))
-        {
-            return Directory.GetCurrentDirectory();
-        }
-
-        while (directory != null)
-        {
-            try
-            {
-                // Look for common project root indicators
-                if (Directory.Exists(Path.Combine(directory, ".git")) ||
-                    Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any() ||
-                    Directory.GetFiles(directory, "*.slnx").Any())
-                {
-                    return directory;
-                }
-            }
-            catch
-            {
-                // If we can't access the directory, continue up
-            }
-
-            var parent = Path.GetDirectoryName(directory);
-            if (parent == directory) // Reached root
-                break;
-            directory = parent;
-        }
-
-        // Fallback to the file's directory or current directory
-        return Path.GetDirectoryName(filePath) ?? Directory.GetCurrentDirectory();
-    }
 }

--- a/src/Slopwatch/Detection/Rules/WarningSuppressRule.cs
+++ b/src/Slopwatch/Detection/Rules/WarningSuppressRule.cs
@@ -283,7 +283,8 @@ public sealed class WarningSuppressRule : IDetectionRule
                 // Look for common project root indicators
                 if (Directory.Exists(Path.Combine(directory, ".git")) ||
                     Directory.Exists(Path.Combine(directory, ".slopwatch")) ||
-                    Directory.GetFiles(directory, "*.sln").Any())
+                    Directory.GetFiles(directory, "*.sln").Any() ||
+                    Directory.GetFiles(directory, "*.slnx").Any())
                 {
                     return directory;
                 }

--- a/src/Slopwatch/Suppression/SuppressionChecker.cs
+++ b/src/Slopwatch/Suppression/SuppressionChecker.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.FileSystemGlobbing;
+using Slopwatch.Analysis;
 using Slopwatch.Configuration;
 using Slopwatch.Detection;
 
@@ -28,13 +29,12 @@ public sealed class SuppressionChecker
     /// Initializes a new instance of <see cref="SuppressionChecker"/>.
     /// </summary>
     /// <param name="context">The detection context.</param>
-    /// <param name="projectRoot">The root directory of the project (for config file loading).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task<SuppressionChecker> CreateAsync(
         DetectionContext context,
-        string projectRoot,
         CancellationToken cancellationToken = default)
     {
+        var projectRoot = ProjectRootLocator.FindRoot(context.FilePath);
         var config = await LoadConfigAsync(projectRoot, cancellationToken);
 
         var inlineSuppressions = context.SyntaxTree != null

--- a/tests/Slopwatch.Tests/Detection/ProjectFileRuleConfigSuppressionTests.cs
+++ b/tests/Slopwatch.Tests/Detection/ProjectFileRuleConfigSuppressionTests.cs
@@ -115,6 +115,62 @@ public class ProjectFileRuleConfigSuppressionTests
         }
     }
 
+    [Fact]
+    public void Test_ConfigSuppression_UsesRepoRootWhenNestedSlnxExists()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var slopwatchDir = Path.Combine(tempRoot, ".slopwatch");
+            Directory.CreateDirectory(slopwatchDir);
+
+            var nestedSolutionDir = Path.Combine(tempRoot, "src", "NestedSolution");
+            Directory.CreateDirectory(nestedSolutionDir);
+            File.WriteAllText(Path.Combine(nestedSolutionDir, "NestedSolution.slnx"), "<Solution />");
+
+            var configPath = Path.Combine(slopwatchDir, "config.json");
+            const string configJson = @"{
+  ""suppressions"": [
+    {
+      ""ruleId"": ""SW005"",
+      ""pattern"": ""src/NestedSolution/Directory.Build.props"",
+      ""justification"": ""CS1591 is no-warned due to documentation file generation requirements""
+    }
+  ],
+  ""globalSuppressions"": []
+}";
+            File.WriteAllText(configPath, configJson);
+
+            const string xml = @"<Project>
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+</Project>";
+
+            var filePath = Path.Combine(nestedSolutionDir, "Directory.Build.props");
+            var context = new DetectionContext(
+                FilePath: filePath,
+                FileName: Path.GetFileName(filePath),
+                Content: xml,
+                SyntaxTree: null,
+                IsTestFile: false
+            );
+
+            var results = RunRule(context);
+
+            Assert.Empty(results);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+    }
+
     private List<DetectionResult> RunRule(DetectionContext context)
     {
         var results = new List<DetectionResult>();

--- a/tests/Slopwatch.Tests/Detection/ProjectFileRuleConfigSuppressionTests.cs
+++ b/tests/Slopwatch.Tests/Detection/ProjectFileRuleConfigSuppressionTests.cs
@@ -1,0 +1,138 @@
+using Slopwatch.Analysis;
+using Slopwatch.Baseline;
+using Slopwatch.Detection;
+using Slopwatch.Detection.Rules;
+using Xunit;
+
+namespace Slopwatch.Tests.Detection;
+
+public class ProjectFileRuleConfigSuppressionTests
+{
+    private readonly ProjectFileRule _rule = new();
+
+    [Fact]
+    public void Test_ConfigSuppression_IgnoresProjectFileIssue()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var slopwatchDir = Path.Combine(tempRoot, ".slopwatch");
+            Directory.CreateDirectory(slopwatchDir);
+
+            var configPath = Path.Combine(slopwatchDir, "config.json");
+            const string configJson = @"{
+  ""suppressions"": [
+    {
+      ""ruleId"": ""SW005"",
+      ""pattern"": ""Directory.Build.props"",
+      ""justification"": ""CS1591 is no-warned due to documentation file generation requirements""
+    }
+  ],
+  ""globalSuppressions"": []
+}";
+            File.WriteAllText(configPath, configJson);
+
+            const string xml = @"<Project>
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+</Project>";
+
+            var filePath = Path.Combine(tempRoot, "Directory.Build.props");
+            var context = new DetectionContext(
+                FilePath: filePath,
+                FileName: Path.GetFileName(filePath),
+                Content: xml,
+                SyntaxTree: null,
+                IsTestFile: false
+            );
+
+            var results = RunRule(context);
+
+            Assert.Empty(results);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Test_ConfigSuppression_PreventsBaselineEntry()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var slopwatchDir = Path.Combine(tempRoot, ".slopwatch");
+            Directory.CreateDirectory(slopwatchDir);
+
+            var configPath = Path.Combine(slopwatchDir, "config.json");
+            const string configJson = @"{
+  ""suppressions"": [
+    {
+      ""ruleId"": ""SW005"",
+      ""pattern"": ""Directory.Build.props"",
+      ""justification"": ""CS1591 is no-warned due to documentation file generation requirements""
+    }
+  ],
+  ""globalSuppressions"": []
+}";
+            File.WriteAllText(configPath, configJson);
+
+            var propsPath = Path.Combine(tempRoot, "Directory.Build.props");
+            const string xml = @"<Project>
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+</Project>";
+            File.WriteAllText(propsPath, xml);
+
+            var analyzer = new FileAnalyzer(new IDetectionRule[] { new ProjectFileRule() });
+            var results = new List<DetectionResult>();
+
+            await foreach (var result in analyzer.AnalyzeDirectoryAsync(tempRoot, new[] { "**/*.props" }))
+            {
+                results.Add(result);
+            }
+
+            var baseline = BaselineFile.Create(results, tempRoot, "Baseline for suppression test");
+
+            Assert.DoesNotContain(baseline.Entries, entry => entry.RuleId == "SW005");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+    }
+
+    private List<DetectionResult> RunRule(DetectionContext context)
+    {
+        var results = new List<DetectionResult>();
+        var enumerable = _rule.AnalyzeAsync(context);
+
+        var enumerator = enumerable.GetAsyncEnumerator();
+        try
+        {
+            while (enumerator.MoveNextAsync().AsTask().Result)
+            {
+                results.Add(enumerator.Current);
+            }
+        }
+        finally
+        {
+            enumerator.DisposeAsync().AsTask().Wait();
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
Fixes #61 

## Changes

This change makes it possible to suppress SW005 through config

That reduces noise for repos that intentionally allow specific project-file settings and make follow-up baseline cleanup possible.

Also adds `.slnx` awareness and `.sln/.slnx` nearest solution support to project root locator code. The nearest solution support mean the previous behavior breaks config-based suppressions whenever a repo keeps `.slopwatch/config.json` at the repository root but has a solution file in a subdirectory. In that layout, files under the nested solution now resolve `projectRoot` to the solution folder, so `SuppressionChecker` looks for `<solution>/.slopwatch/config.json` and silently stops honoring suppressions; the same regression is present in the other rule-local `GetProjectRoot` helpers so I refactored that to a shared method instead. Added some testing around that

Some not strictly necessary cleanup of names/comments but felt worthwhile

It's split up into multiple commits to make the story clearer (starting with a failing test) so advisable to review each commit and then the entirety.

## Manual testing

Ran:

`dotnet run --project src/Slopwatch.Cmd -- analyze -d C:\path\to\other-project --no-baseline --fail-on warning`

Tested with this config:

```json
{
  "suppressions": [
    {
      "ruleId": "SW005",
      "pattern": "Directory.Build.props",
      "justification": "CS1591 is no warned due to enablement of generating a documentation file to allow IDE0005 analyzer to work but we don't care for enforcing the documentation of all public members or types, for more info see https://github.com/dotnet/roslyn/issues/41640"
    }
  ],
  "globalSuppressions": []
}
```
So the issue is not in the config file itself it was just not wired up correctly

(and also `dotnet run --project src\Slopwatch.Cmd -- analyze -d . --fail-on warning` to make sure no slop got introduced, needed to run `dotnet run --project src\Slopwatch.Cmd -- analyze --update-baseline` after that to get rid of the SW003 that was previously baselined in another file, see baseline cleanup section below for further work that could/should be done)

`dotnet run --project src/Slopwatch.Cmd -- analyze -d . --fail-on warning --stats`

>Scan complete: 0 issue(s) found

>Stats: 54 files analyzed in 0,53s

So no measurable impact, I got this on dev right now

`dotnet run --project src/Slopwatch.Cmd -- analyze -d . --fail-on warning --stats`

>Scan complete: 0 issue(s) found

>Stats: 52 files analyzed in 0,54s

## Automated testing
Added new unit tests, one initial failing test and then after the implementation for some more scenarios

`dotnet test` succeeded

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

## AI Disclosure

I used GPT 5.4 High in Codex to help me research and code most of it

## Baseline cleanup potential

This change also creates a good opportunity to clean up the current repo baseline. With the new behavior, some existing entries can be removed rather than preserved forever, including reducing the SW003 baseline down to a single entry.

I checked the current baseline flow in code:

`slopwatch init` will not rewrite an existing baseline unless `--force` is provided.
`slopwatch analyze --update-baseline` (unexpectedly) only adds new entries to the baseline. (Should there be a bug created for this?)
The current update path does not remove stale entries that no longer appear after analysis.
So if we want to actually refresh or shrink the baseline, we need to force a full regeneration rather than rely on `--update-baseline`.

So with `slopwatch init --force` the new base line with the patch in this PR would be

<details><summary>baseline.json</summary>
<p>

```json
{
  "version": 1,
  "createdAt": "2026-04-14T16:17:19.767334+00:00",
  "updatedAt": "2026-04-14T16:17:19.770061+00:00",
  "description": "Initial baseline created by 'slopwatch init' on 2026-04-14 16:17:19 UTC",
  "entries": [
    {
      "hash": "7a02787409549c96",
      "ruleId": "SW003",
      "filePath": "src/Slopwatch/Analysis/FileAnalyzer.cs",
      "lineNumber": 213,
      "codeSnippet": "catch\r\n            {\r\n                // If parsing fails, continue without syntax tree\r\n                // The content will still be available for text-based analysis\r\n            }",
      "message": "Empty catch block swallows exceptions without handling",
      "baselinedAt": "2026-04-14T16:17:19.769954+00:00"
    },
    {
      "hash": "e45be01c2f7ebb97",
      "ruleId": "SW003",
      "filePath": "src/Slopwatch/Analysis/ProjectRootLocator.cs",
      "lineNumber": 38,
      "codeSnippet": "catch\r\n            {\r\n                // If we can't access the directory, continue up.\r\n            }",
      "message": "Empty catch block swallows exceptions without handling",
      "baselinedAt": "2026-04-14T16:17:19.7700606+00:00"
    }
  ]
}
```

</p>
</details> 

Should the description change from `Initial baseline created by 'slopwatch init'` to `Initial baseline created by 'slopwatch init --force'` when `--force` is used?