### PR TITLE
Prepare release v0.4.1 (#86)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <PackageReleaseNotes>**Bug Fixes:**
 * `--config` flag now properly loads custom suppression configurations during analysis - the option was previously documented but not wired into the analysis pipeline (PR #71)
 * Hook mode now falls back to full file analysis when `git status` is unavailable (e.g., outside a git repository), instead of silently returning no results (PR #71)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+#### 0.4.1 May 28th 2026 ####
+
+**Bug Fixes:**
+* SW005 suppression via config now works correctly - the `--config` flag is respected for project file suppressions, enabling baseline cleanup of intentional MSBuild settings (PR #80, fixes #61)
+* `ProjectRootLocator` now uses a shared implementation across all detection rules, eliminating inconsistent path resolution between rules (PR #80)
+* `.slnx` solution files are now fully supported — nearest solution detection includes `.slnx` alongside `.sln` for proper config file resolution in nested project layouts (PR #80)
+* Added XML `slopwatch-ignore` comment suppression support for project files (`.props`, `.targets`) — matches the existing suppression pattern for code files (PR #80)
+
+**Compatibility:**
+* SDK toolchain bumped to .NET 10.0.300 (PR #83)
+
 #### 0.4.0 March 2nd 2026 ####
 
 **Bug Fixes:**


### PR DESCRIPTION
Merges the release preparation for 0.4.1:

**Bug Fixes:**
* SW005 suppression via config now works correctly — the  flag is respected for project file suppressions (PR #80, fixes #61)
*  now uses a shared implementation across all detection rules (PR #80)
*  solution files fully supported with nearest solution detection (PR #80)
* XML  comment suppression support for project files (PR #80)

**Compatibility:**
* SDK toolchain bumped to .NET 10.0.300 (PR #83)

**CI:**
* Updated release automation to extract only the latest release block (#76)
* Bumped CI dependencies (#74, #78, #79, #85)
