### PR TITLE
Release v0.4.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,13 +5,13 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionPrefix>0.4.2</VersionPrefix>
     <PackageReleaseNotes>**Bug Fixes:**
-* `--config` flag now properly loads custom suppression configurations during analysis - the option was previously documented but not wired into the analysis pipeline (PR #71)
-* Hook mode now falls back to full file analysis when `git status` is unavailable (e.g., outside a git repository), instead of silently returning no results (PR #71)
+* `--update-baseline` now correctly adds new entries and removes stale ones — uses hash-based deduplication to keep your baseline in sync (PR #97)
 
-**Documentation:**
-* Updated README examples to reflect correct `.slopwatch/config.json` schema, SW006 severity levels, and local tool installation instructions (PR #71)</PackageReleaseNotes>
+**Dependencies:**
+* Bumped Microsoft.CodeAnalysis.CSharp from 5.0.0 to 5.3.0 (PR #92)
+* Bumped Akka.Streams from 1.5.60 to 1.5.68 (PR #88)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+#### 0.4.2 June 10th 2026 ####
+
+**Bug Fixes:**
+* `--update-baseline` now correctly adds new entries and removes stale ones — uses hash-based deduplication to keep your baseline in sync (PR #97)
+
+**Dependencies:**
+* Bumped Microsoft.CodeAnalysis.CSharp from 5.0.0 to 5.3.0 (PR #92)
+* Bumped Akka.Streams from 1.5.60 to 1.5.68 (PR #88)
+
 #### 0.4.1 May 28th 2026 ####
 
 **Bug Fixes:**


### PR DESCRIPTION
## Release v0.4.2

**Bug Fixes:**
* `--update-baseline` now correctly adds new entries and removes stale ones — uses hash-based deduplication to keep your baseline in sync (PR #97)

**Dependencies:**
* Bumped Microsoft.CodeAnalysis.CSharp from 5.0.0 to 5.3.0 (PR #92)
* Bumped Akka.Streams from 1.5.60 to 1.5.68 (PR #88)

Merging this PR will trigger the `publish_nuget.yml` workflow on tag push.