### PR TITLE
Update baseline

### DIFF
--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,81 +1,9 @@
 {
   "version": 1,
   "createdAt": "2026-01-11T16:03:39.2213093+00:00",
-  "updatedAt": "2026-04-13T20:06:27.3536741+00:00",
+  "updatedAt": "2026-07-14T21:38:40.3877224+00:00",
   "description": "Initial baseline created by 'slopwatch init' on 2026-01-11 16:03:39 UTC",
   "entries": [
-    {
-      "hash": "44fac096fcddc658",
-      "ruleId": "SW005",
-      "filePath": "tests/Slopwatch.Tests.Fixtures/Slopwatch.Tests.Fixtures.csproj",
-      "lineNumber": 15,
-      "codeSnippet": "<NoWarn>$(NoWarn);xUnit1013;xUnit1030;xUnit1031</NoWarn>",
-      "message": "Adding warnings to NoWarn: xUnit1013;xUnit1030;xUnit1031",
-      "baselinedAt": "2026-01-11T16:03:39.2281131+00:00"
-    },
-    {
-      "hash": "c96fc7a7b7817f1f",
-      "ruleId": "SW005",
-      "filePath": "tests/Slopwatch.Tests.Fixtures/Slopwatch.Tests.Fixtures.csproj",
-      "lineNumber": 17,
-      "codeSnippet": "<NoWarn>$(NoWarn);CS0169;CS8618</NoWarn>",
-      "message": "Adding warnings to NoWarn: CS0169;CS8618",
-      "baselinedAt": "2026-01-11T16:03:39.2282534+00:00"
-    },
-    {
-      "hash": "6d8d399385a50aae",
-      "ruleId": "SW005",
-      "filePath": "tests/Slopwatch.Tests.Fixtures/Slopwatch.Tests.Fixtures.csproj",
-      "lineNumber": 13,
-      "codeSnippet": "<TreatWarningsAsErrors>false</TreatWarningsAsErrors>",
-      "message": "TreatWarningsAsErrors is disabled - warnings will not fail the build",
-      "baselinedAt": "2026-01-11T16:03:39.228261+00:00"
-    },
-    {
-      "hash": "49112ea034f5802e",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch/Detection/Rules/ProjectFileRule.cs",
-      "lineNumber": 71,
-      "codeSnippet": "catch\n        {\n            // Invalid XML - skip analysis\n            yield break;\n        }",
-      "message": "Catch block uses overly broad exception type: all exceptions",
-      "baselinedAt": "2026-01-11T16:03:39.2282739+00:00"
-    },
-    {
-      "hash": "3d4ffc58ec681ce9",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch/Detection/Rules/WarningSuppressRule.cs",
-      "lineNumber": 291,
-      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
-      "message": "Empty catch block swallows exceptions without handling",
-      "baselinedAt": "2026-01-11T16:03:39.2282846+00:00"
-    },
-    {
-      "hash": "e2e0952eec72f83c",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch/Detection/Rules/EmptyCatchBlockRule.cs",
-      "lineNumber": 268,
-      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
-      "message": "Empty catch block swallows exceptions without handling",
-      "baselinedAt": "2026-01-11T16:03:39.2282935+00:00"
-    },
-    {
-      "hash": "6f8015540e8ff17d",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch/Detection/Rules/DisabledTestRule.cs",
-      "lineNumber": 290,
-      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
-      "message": "Empty catch block swallows exceptions without handling",
-      "baselinedAt": "2026-01-11T16:03:39.2282987+00:00"
-    },
-    {
-      "hash": "c4d17214afabd920",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch/Detection/Rules/TimeoutJigglingRule.cs",
-      "lineNumber": 278,
-      "codeSnippet": "catch\n            {\n                // If we can't access the directory, continue up\n            }",
-      "message": "Empty catch block swallows exceptions without handling",
-      "baselinedAt": "2026-01-11T16:03:39.2283035+00:00"
-    },
     {
       "hash": "7a02787409549c96",
       "ruleId": "SW003",
@@ -84,51 +12,6 @@
       "codeSnippet": "catch\n            {\n                // If parsing fails, continue without syntax tree\n                // The content will still be available for text-based analysis\n            }",
       "message": "Empty catch block swallows exceptions without handling",
       "baselinedAt": "2026-01-11T16:03:39.2283094+00:00"
-    },
-    {
-      "hash": "17d638517a63fa31",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch/Suppression/SuppressionChecker.cs",
-      "lineNumber": 207,
-      "codeSnippet": "catch\n        {\n            // If config file is invalid, treat as if no config exists\n            return null;\n        }",
-      "message": "Catch block uses overly broad exception type: all exceptions",
-      "baselinedAt": "2026-01-11T16:03:39.228316+00:00"
-    },
-    {
-      "hash": "ede696709edf61e1",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch.Cmd/Program.cs",
-      "lineNumber": 39,
-      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\"Unhandled error: {ex.Message}\");\n            return 2;\n        }",
-      "message": "Catch block uses overly broad exception type: Exception",
-      "baselinedAt": "2026-01-11T16:03:39.2283215+00:00"
-    },
-    {
-      "hash": "f5ff8daa96d29b5e",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch.Cmd/Commands/AnalyzeCommand.cs",
-      "lineNumber": 221,
-      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\"Error during analysis: {ex.Message}\");\n            if (ex.InnerException is not null)\n            {\n    // ...",
-      "message": "Catch block uses overly broad exception type: Exception",
-      "baselinedAt": "2026-01-11T16:03:39.2283274+00:00"
-    },
-    {
-      "hash": "7349024738d80102",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch.Cmd/Commands/ListRulesCommand.cs",
-      "lineNumber": 54,
-      "codeSnippet": "catch (Exception ex)\n        {\n            Console.Error.WriteLine($\"Error listing rules: {ex.Message}\");\n            return Task.FromResult(2);\n        }",
-      "message": "Catch block uses overly broad exception type: Exception",
-      "baselinedAt": "2026-01-11T16:03:39.2283335+00:00"
-    },
-    {
-      "hash": "382d72c37162f5a6",
-      "ruleId": "SW003",
-      "filePath": "src/Slopwatch.Cmd/Commands/InitCommand.cs",
-      "lineNumber": 149,
-      "codeSnippet": "catch (Exception ex)\n        {\n            await Console.Error.WriteLineAsync($\"Error during initialization: {ex.Message}\");\n            return 2;\n        }",
-      "message": "Catch block uses overly broad exception type: Exception",
-      "baselinedAt": "2026-01-11T16:03:39.2283388+00:00"
     },
     {
       "hash": "e45be01c2f7ebb97",


### PR DESCRIPTION
with `dotnet run --project src\Slopwatch.Cmd -- analyze --update-baseline`

Fixes N/A

## Changes

Baseline was fixed to also remove stale entries but it was never applied to the repo itself 
Ref: https://github.com/Aaronontheweb/dotnet-slopwatch/pull/97

```
dotnet run --project src\Slopwatch.Cmd -- analyze --update-baseline
Updated baseline at: C:\repos\frulfump\dotnet-slopwatch\.slopwatch/baseline.json
  Added: 0 new entries
  Removed: 13 stale entries
  Kept: 2 already baselined
  Total: 2 entries
 ```

## Checklist

(The checklist was still referencing Akka, thought that was fixed hmm)

### Latest `dev` Benchmarks 

N/A

### This PR's Benchmarks

N/A
