### PR TITLE
docs: add Discord community badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <p align="center">
   <a href="https://www.nuget.org/packages/Slopwatch.Cmd"><img src="https://img.shields.io/nuget/v/Slopwatch.Cmd.svg" alt="NuGet"></a>
   <a href="https://github.com/Aaronontheweb/dotnet-slopwatch/blob/dev/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
+  <a href="https://discord.gg/2smteJ8sGh"><img src="https://img.shields.io/discord/1494176300657545318?label=Discord&logo=discord&color=5865F2" alt="Discord"></a>
 </p>
 
 ---


### PR DESCRIPTION
Adds a Discord badge to the README header badge row, linking to the Netclaw community server.

## Changes
- New badge in the badge row ([README.md](https://github.com/Aaronontheweb/dotnet-slopwatch/blob/feature/discord-badge/README.md#L15)): shields.io Discord badge using the server guild ID, linking to https://discord.gg/2smteJ8sGh
- Badge verified live — resolves 200 image/svg+xml and shows member count

Closes #120
